### PR TITLE
Ver 75892: Explain copy

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -175,7 +175,8 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
     val ret = for {
 
       // Explain copy first to verify it's valid.
-      _ <- jdbcLayer.execute("EXPLAIN " + copyStatement)
+      rs <- jdbcLayer.query("EXPLAIN " + copyStatement)
+      _ = rs.close()
 
       // Real copy
       rowsCopied <- jdbcLayer.executeUpdate(copyStatement)

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -51,6 +51,13 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     resultSet
   }
 
+  private def getEmptyResultSet() : ResultSet = {
+    val resultSet = mock[ResultSet]
+    (resultSet.close _).expects().returning()
+
+    resultSet
+  }
+
   // TODO: Change this based on write modes
   it should "Create a table if it doesn't exist" in {
     val schema = new StructType(Array(StructField("col1", IntegerType)))
@@ -235,7 +242,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
-    (jdbcLayerInterface.execute _).expects("EXPLAIN " + expected).returning(Right(()))
+    (jdbcLayerInterface.query _).expects("EXPLAIN " + expected).returning(Right(getEmptyResultSet()))
     (jdbcLayerInterface.executeUpdate _).expects(expected).returning(Right(1))
     (jdbcLayerInterface.query _).expects("SELECT COUNT(*) as count FROM dummy_id_COMMITS").returning(Right(getCountTableResultSet()))
     (jdbcLayerInterface.close _).expects().returning()
@@ -267,7 +274,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
-    (jdbcLayerInterface.execute _).expects("EXPLAIN " + expected).returning(Right(()))
+    (jdbcLayerInterface.query _).expects("EXPLAIN " + expected).returning(Right(getEmptyResultSet()))
     (jdbcLayerInterface.executeUpdate _).expects(expected).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*).returning(Right(getCountTableResultSet()))
     (jdbcLayerInterface.close _).expects().returning()
@@ -292,7 +299,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
-    (jdbcLayerInterface.execute _).expects(*).returning(Left(JDBCLayerError(SyntaxError)))
+    (jdbcLayerInterface.query _).expects(*).returning(Left(JDBCLayerError(SyntaxError)))
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
     (jdbcLayerInterface.close _).expects().returning()
 
@@ -320,7 +327,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
-    (jdbcLayerInterface.execute _).expects(*).returning(Right(()))
+    (jdbcLayerInterface.query _).expects(*).returning(Right(getEmptyResultSet()))
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*).returning(Right(getCountTableResultSet()))
     (jdbcLayerInterface.execute _).expects(*).returning(Right(()))
@@ -350,7 +357,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
-    (jdbcLayerInterface.execute _).expects(*).returning(Right(()))
+    (jdbcLayerInterface.query _).expects(*).returning(Right(getEmptyResultSet()))
     (jdbcLayerInterface.executeUpdate _).expects("COPY dummy (col1,col3,col2) FROM 'hdfs://example-hdfs:8020/tmp/test/*.parquet' ON ANY NODE parquet REJECTED DATA AS TABLE dummy_id_COMMITS NO COMMIT").returning(Right(1))
     (jdbcLayerInterface.query _).expects(*).returning(Right(getCountTableResultSet()))
     (jdbcLayerInterface.execute _).expects(*).returning(Right(()))
@@ -378,7 +385,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
-    (jdbcLayerInterface.execute _).expects(*).returning(Right(()))
+    (jdbcLayerInterface.query _).expects(*).returning(Right(getEmptyResultSet()))
     (jdbcLayerInterface.executeUpdate _).expects("COPY dummy (\"col1\",\"col5\") FROM 'hdfs://example-hdfs:8020/tmp/test/*.parquet' ON ANY NODE parquet REJECTED DATA AS TABLE dummy_id_COMMITS NO COMMIT").returning(Right(1))
     (jdbcLayerInterface.query _).expects(*).returning(Right(getCountTableResultSet()))
     (jdbcLayerInterface.execute _).expects(*).returning(Right(()))
@@ -405,7 +412,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
-    (jdbcLayerInterface.execute _).expects(*).returning(Right(()))
+    (jdbcLayerInterface.query _).expects(*).returning(Right(getEmptyResultSet()))
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*).returning(Right(getCountTableResultSet(6)))
     (jdbcLayerInterface.close _).expects().returning()
@@ -434,7 +441,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
-    (jdbcLayerInterface.execute _).expects(*).returning(Right(()))
+    (jdbcLayerInterface.query _).expects(*).returning(Right(getEmptyResultSet()))
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*).returning(Right(getCountTableResultSet(4)))
     (jdbcLayerInterface.close _).expects().returning()
@@ -460,7 +467,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(1))
-    (jdbcLayerInterface.execute _).expects(*).returning(Right(()))
+    (jdbcLayerInterface.query _).expects(*).returning(Right(getEmptyResultSet()))
     (jdbcLayerInterface.executeUpdate _).expects(*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*).returning(Right(getCountTableResultSet()))
     (jdbcLayerInterface.close _).expects().returning()


### PR DESCRIPTION
### Summary

Add explain copy before actual copy to Vertica.

### Description

Add explain copy call. Since this can fail on a table with no projections, also add an invalid copy statement which forces this projection to be created.

### Related Issue

VER-75892

### Additional Reviewers
@kylepbit
@raymond-lum 
@jonathanl-bq 
@NerdLogic 