### PR TITLE
Ver 76282: Audit and improve error messages for error handling

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -193,7 +193,7 @@ class VerticaDistributedFilesystemReadPipe(
       _ <- fileStoreLayer.createDir(fileStoreConfig.address) match {
         case Left(err) =>
           err.getError match {
-            case CreateDirectoryAlreadyExistsError() =>
+            case CreateDirectoryAlreadyExistsError(_) =>
               logger.debug("Directory already existed: " + fileStoreConfig.address)
               Right(())
             case _ => Left(err.context("Failed to create directory: " + fileStoreConfig.address))

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -57,7 +57,7 @@ trait JdbcLayerInterface {
   /**
     * Close and cleanup
     */
-  def close(): Unit
+  def close(): ConnectorResult[Unit]
 
 
   /**
@@ -92,53 +92,37 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
   private val jdbcURI = "jdbc:vertica://" + cfg.host + ":" + cfg.port + "/" + cfg.db
   logger.info("Connecting to Vertica with URI: " + jdbcURI)
 
-  var connection: Option[Connection] = None
-  try{
-    val conn = DriverManager.getConnection(jdbcURI, prop)
-    if(conn.isValid(0))
-    {
-      conn.setAutoCommit(false)
-      logger.info("Successfully connected to Vertica.")
-      connection = Some(conn)
-    }
+  private val connection: ConnectorResult[Connection] = {
+    Try { DriverManager.getConnection(jdbcURI, prop) }
+      .toEither.left.map(handleConnectionException)
+      .flatMap(conn =>
+        this.useConnection(conn, c => {
+          c.setAutoCommit(false)
+          logger.info("Successfully connected to Vertica.")
+          c
+        }, handleConnectionException).left.map(_.context("Initial connection was not valid.")))
   }
-  catch {
-    case e: java.sql.SQLException => logger.error("SQL Exception when trying to connect to Vertica.", e)
-    case e: Throwable => logger.error("Unexpected Exception when trying to connect to Vertica.", e)
+
+  private def handleConnectionException(e: Throwable): ConnectorError = {
+    e match {
+      case e: java.sql.SQLException =>
+        ConnectionSqlError(e)
+      case e: Throwable =>
+        ConnectionError(e)
+    }
   }
 
   /**
     * Gets a statement object or connection error if something is wrong.
     */
   private def getStatement: ConnectorResult[Statement] = {
-    connection match {
-      case Some(conn) =>
-        if (conn.isValid(0)) {
-          val stmt = conn.createStatement()
-          Right(stmt)
-        } else {
-          Left(ConnectionDownError())
-        }
-      case None =>
-        Left(ConnectionError())
-    }
+    this.connection.flatMap(conn => this.useConnection(conn, c => c.createStatement(), handleConnectionException)
+      .left.map(_.context("getStatement: Error while trying to create statement.")))
   }
 
   private def getPreparedStatement(sql: String): ConnectorResult[PreparedStatement] = {
-    connection match {
-      case Some(conn) =>
-        if(conn.isValid(0))
-        {
-          val stmt = conn.prepareStatement(sql)
-
-          Right(stmt)
-        }
-        else {
-          Left(ConnectionDownError())
-        }
-      case None =>
-        Left(ConnectionError())
-    }
+    this.connection.flatMap(conn => this.useConnection(conn, c => c.prepareStatement(sql), handleConnectionException)
+      .left.map(_.context("getPreparedStatement: Error while getting prepared statement.")))
   }
 
   /**
@@ -229,38 +213,36 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
   /**
    * Closes the connection
    */
-  def close(): Unit = {
+  def close(): ConnectorResult[Unit] = {
     logger.debug("Closing connection.")
-    connection match {
-      case Some(conn) =>
-        if(conn.isValid(0)){
-          conn.close()
-        }
-      case None => ()
-    }
+    this.connection.flatMap(conn => this.useConnection(conn, c => c.close(), handleJDBCException)
+      .left.map(_.context("close: JDBC Error closing the connection.")))
   }
 
   def commit(): ConnectorResult[Unit] = {
     logger.debug("Commiting.")
-    this.useConnection(conn => conn.commit())
-      .left.map(err => err.context("Error getting connection while commiting"))
+    this.connection.flatMap(conn => this.useConnection(conn, c => c.commit(), handleJDBCException)
+      .left.map(_.context("commit: JDBC Error while commiting.")))
   }
 
   def rollback(): ConnectorResult[Unit] = {
     logger.debug("Rolling back.")
-    this.useConnection(conn => conn.rollback())
-      .left.map(err => err.context("Error getting connection while rolling back"))
+    this.connection.flatMap(conn => this.useConnection(conn, c => c.rollback(), handleJDBCException)
+      .left.map(_.context("rollback: JDBC Error while rolling back.")))
   }
 
-  private def useConnection(action: Connection => Unit): ConnectorResult[Unit] = {
-    connection match {
-      case Some(conn) =>
-        if (conn.isValid(0)){
-          Try { action(conn) }.toEither.left.map(e => handleJDBCException(e))
-        } else {
-          Left(ConnectionDownError())
-        }
-      case None => Left(ConnectionError())
+  private def useConnection[T](
+                                connection: Connection,
+                                action: Connection => T,
+                                exceptionCatcher: Throwable => ConnectorError): ConnectorResult[T] = {
+    try {
+      if (connection.isValid(0)) {
+        Right(action(connection))
+      } else {
+        Left(ConnectionDownError())
+      }
+    } catch {
+      case e: Throwable => Left(exceptionCatcher(e))
     }
   }
 }

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -16,7 +16,7 @@ package com.vertica.spark.util.cleanup
 import cats.implicits.toTraverseOps
 import com.vertica.spark.config.LogProvider
 import com.vertica.spark.datasource.fs.FileStoreLayerInterface
-import com.vertica.spark.util.error.{CleanupError, ConnectorError, FileSystemError}
+import com.vertica.spark.util.error.{CleanupError, ConnectorError, ParentDirMissingError}
 import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
 import org.apache.hadoop.fs.Path
 
@@ -83,7 +83,7 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
   private def getParentHadoopPath(path: String): ConnectorResult[String] = {
     val p = new Path(s"$path")
     val parent = p.getParent
-    if(parent != null) Right(parent.toString) else Left(FileSystemError().context("Could not retrieve parent path of file: " + path))
+    if(parent != null) Right(parent.toString) else Left(ParentDirMissingError(path))
   }
 
   private def performCleanup(fileStoreLayer: FileStoreLayerInterface, fileCleanupInfo: FileCleanupInfo ): ConnectorResult[Unit] = {

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -194,7 +194,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val uniqueId = "unique-id"
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
     val schemaToolsInterface = mock[SchemaToolsInterface]
 
     val v1: Int = 1
@@ -276,7 +276,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.query _).expects("EXPLAIN " + expected, *).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(expected, *).returning(Right(1))
     (jdbcLayerInterface.query _).expects("SELECT COUNT(*) as count FROM \"dummy_id_COMMITS\"", *).returning(Right(getCountTableResultSet()))
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.execute _).expects(*,*).returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
@@ -308,7 +308,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.query _).expects("EXPLAIN " + expected, *).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(expected, *).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*, *).returning(Right(getCountTableResultSet()))
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.execute _).expects(*, *).returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
     val schemaToolsInterface = mock[SchemaToolsInterface]
@@ -332,7 +332,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.executeUpdate _).expects(*, *).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*, *).returning(Left(SyntaxError(new Exception())))
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
     (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename.getFullTableName, schema).returning(Right(""))
@@ -365,7 +365,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getCountTableResultSet()))
     (jdbcLayerInterface.execute _).expects(*,*).returning(Right(()))
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
@@ -395,7 +395,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.executeUpdate _).expects("COPY \"dummy\" (col1,col3,col2) FROM 'hdfs://example-hdfs:8020/tmp/test/*.parquet' ON ANY NODE parquet REJECTED DATA AS TABLE \"dummy_id_COMMITS\" NO COMMIT", *).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*, *).returning(Right(getCountTableResultSet()))
     (jdbcLayerInterface.execute _).expects(*,*).returning(Right(()))
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
@@ -423,7 +423,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.executeUpdate _).expects("COPY \"dummy\" (\"col1\",\"col5\") FROM 'hdfs://example-hdfs:8020/tmp/test/*.parquet' ON ANY NODE parquet REJECTED DATA AS TABLE \"dummy_id_COMMITS\" NO COMMIT",*).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getCountTableResultSet()))
     (jdbcLayerInterface.execute _).expects(*,*).returning(Right(()))
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
@@ -449,7 +449,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getCountTableResultSet(6)))
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
@@ -478,7 +478,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getCountTableResultSet(4)))
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
@@ -504,7 +504,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getCountTableResultSet()))
-    (jdbcLayerInterface.close _).expects().returning()
+    (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     // Drop statement

--- a/connector/src/test/scala/com/vertica/spark/util/cleanup/CleanupUtilsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/cleanup/CleanupUtilsTest.scala
@@ -17,6 +17,7 @@ import ch.qos.logback.classic.Level
 import com.vertica.spark.config.LogProvider
 import com.vertica.spark.datasource.fs.FileStoreLayerInterface
 import com.vertica.spark.util.error.{CreateFileError, RemoveFileError}
+import org.apache.hadoop.fs.Path
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
@@ -91,25 +92,25 @@ class CleanupUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
     val filename = "file.parquet"
 
     val fileStoreLayer = mock[FileStoreLayerInterface]
-    (fileStoreLayer.createFile _).expects(filename+".cleanup0").returning(Left(CreateFileError(new Exception())))
+    (fileStoreLayer.createFile _).expects(filename+".cleanup0").returning(Left(CreateFileError(new Path(filename), new Exception())))
 
     cleanupUtils.checkAndCleanup(fileStoreLayer, FileCleanupInfo(filename, 0, 3)) match {
       case Right(_) => ()
       case Left(err) => assert(err.getError match {
-        case CreateFileError(_) => true
+        case CreateFileError(_, _) => true
         case _ => false
       })
     }
 
     (fileStoreLayer.createFile _).expects(filename+".cleanup1").returning(Right(()))
-    (fileStoreLayer.fileExists _).expects(filename+".cleanup0").returning(Left(CreateFileError(new Exception())))
+    (fileStoreLayer.fileExists _).expects(filename+".cleanup0").returning(Left(CreateFileError(new Path(filename), new Exception())))
     (fileStoreLayer.fileExists _).expects(filename+".cleanup1").returning(Right(true))
     (fileStoreLayer.fileExists _).expects(filename+".cleanup2").returning(Right(true))
 
     cleanupUtils.checkAndCleanup(fileStoreLayer, FileCleanupInfo(filename, 1, 3)) match {
       case Right(_) => ()
       case Left(err) => assert(err.getError match {
-        case CreateFileError(_) => true
+        case CreateFileError(_, _) => true
         case _ => false
       })
     }
@@ -118,14 +119,14 @@ class CleanupUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
     (fileStoreLayer.fileExists _).expects(filename+".cleanup0").returning(Right(true))
     (fileStoreLayer.fileExists _).expects(filename+".cleanup1").returning(Right(true))
     (fileStoreLayer.fileExists _).expects(filename+".cleanup2").returning(Right(true))
-    (fileStoreLayer.removeFile _).expects(filename+".cleanup0").returning(Left(RemoveFileError(new Exception())))
-    (fileStoreLayer.removeFile _).expects(filename+".cleanup1").returning(Left(RemoveFileError(new Exception())))
-    (fileStoreLayer.removeFile _).expects(filename+".cleanup2").returning(Left(RemoveFileError(new Exception())))
+    (fileStoreLayer.removeFile _).expects(filename+".cleanup0").returning(Left(RemoveFileError(new Path(filename), new Exception())))
+    (fileStoreLayer.removeFile _).expects(filename+".cleanup1").returning(Left(RemoveFileError(new Path(filename), new Exception())))
+    (fileStoreLayer.removeFile _).expects(filename+".cleanup2").returning(Left(RemoveFileError(new Path(filename), new Exception())))
 
     cleanupUtils.checkAndCleanup(fileStoreLayer, FileCleanupInfo(filename, 2, 3)) match {
       case Right(_) => ()
       case Left(err) => assert(err.getError match {
-        case RemoveFileError(_) => true
+        case RemoveFileError(_, _) => true
         case _ => false
       })
     }

--- a/connector/src/test/scala/com/vertica/spark/util/error/ErrorHandlingTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/error/ErrorHandlingTest.scala
@@ -152,4 +152,25 @@ class ErrorHandlingTest extends AnyFlatSpec with BeforeAndAfterAll with MockFact
       case Right(_) => fail
     }
   }
+
+  it should "get the error messages from a SchemaDiscoveryError" in {
+    val error = SchemaDiscoveryError(None)
+    assert(error.getFullContext == "Failed to discover the schema of the table. " +
+      "There may be an issue with connectivity to the database.")
+
+    assert(error.getUserMessage == "Failed to discover the schema of the table. This is likely a bug and should be reported to the developers here:\n" +
+      "https://github.com/vertica/spark-connector/issues")
+  }
+
+  it should "get the error messages from a SchemaDiscoveryError wrapping another error" in {
+    val error = SchemaDiscoveryError(Some(MyError()))
+    assert(error.getFullContext == "Failed to discover the schema of the table. " +
+      "There may be an issue with connectivity to the database.\nMy test error")
+  }
+
+  it should "get the error messages from a SchemaColumnListError" in {
+    val error = SchemaColumnListError(MyError())
+    assert(error.getFullContext == "Failed to create a valid column list for the write operation " +
+      "due to mismatch with the existing table.\nMy test error")
+  }
 }

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -395,7 +395,7 @@ class SchemaToolsTests extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
   it should "fail when there's an error connecting to database" in {
     val jdbcLayer = mock[JdbcLayerInterface]
 
-    (jdbcLayer.query _).expects(*,*).returning(Left(ConnectionError()))
+    (jdbcLayer.query _).expects(*,*).returning(Left(ConnectionError(new Exception())))
 
     new SchemaTools(logProvider).readSchema(jdbcLayer, tablename) match {
       case Left(err) =>

--- a/connector/src/test/scala/com/vertica/spark/util/table/TableUtilsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/table/TableUtilsTest.scala
@@ -93,7 +93,7 @@ class TableUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with MockFactory
     (jdbcLayerInterface.query _).expects(
       *,
       *
-    ).returning(Left(ConnectionError()))
+    ).returning(Left(ConnectionError(new Exception())))
 
     val schemaTools = mock[SchemaToolsInterface]
 
@@ -249,7 +249,7 @@ class TableUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with MockFactory
     (jdbcLayerInterface.query _).expects(
       *,*
     ).returning(Right(getTableResultSet(exists = false)))
-    (jdbcLayerInterface.execute _).expects(*,*).returning(Left(ConnectionError()))
+    (jdbcLayerInterface.execute _).expects(*,*).returning(Left(ConnectionError(new Exception())))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
 


### PR DESCRIPTION
### Summary

This improves error messages for all of the most common errors we expect users to run into. The remaining error messages will be updated in a separate PR. Integration tests will be updated separately in a different PR.

### Description

Most of the changes here are changes to the error types in ErrorHandling.scala. There are some changes outside of this to make the JDBC layer cleaner and more robust, including updates to the close method of that interface to account for exceptions being thrown.

### Related Issue

http://jira.verticacorp.com:8080/jira/browse/VER-76282

### Additional Reviewers

@alexr-bq 
@NerdLogic 
