### PR TITLE
Add cause to error when setting log level

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/config/GenericConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/GenericConfig.scala
@@ -29,7 +29,7 @@ final case class LogProvider(logLevel: Level) {
   def getLogger(c: Class[_]): Logger = {
     val logger = Logger(c)
     Try{logger.underlying.asInstanceOf[classic.Logger].setLevel(logLevel) } match {
-      case Failure(_) => logger.error("Could not set log level based on configuration.")
+      case Failure(cause) => logger.error("Could not set log level based on configuration.", cause)
       case Success(_) => ()
     }
 


### PR DESCRIPTION
### Summary

Small PR to add more context when we fail to set the log level.

### Description

Just a one line change to add the cause to the error when we fail to set the log level.

### Related Issue

None

### Additional Reviewers

@alexr-bq 
@NerdLogic 
