### PR TITLE
Fix read logic issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,6 @@ The connector supports basic Spark types. Complex types are not currently suppor
 
 ## Known Issues
 
-### Cleanup on Vertica to Spark path
-
-When reading from vertica, parquet files used in intermediary are not currently cleaned up. This is a temporarily disabled feature while an issue with cleanup is investigated.
-
-The hadoop command line tool can be used to clean up files.
-
-```shell
-hadoop fs -rm user/release/s2v/74727063_613a_49d0_98e4_e806f5301ecf
-```
-
 ### Old timestamps
 
 If using very old dates and timestamps, you may run into an error like the following:

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -127,7 +127,8 @@ class VerticaDistributedFilesystemReadPipe(
       while(j < size){
         if(i == rowGroupRoom-1){ // Reached end of partition, cut off here
           val rangeIdx = incrementRangeMapGetIndex(rangeCountMap, m.filename)
-          val frange = ParquetFileRange(m.filename, low, j, Some(rangeIdx))
+          //val frange = ParquetFileRange(m.filename, low, j, Some(rangeIdx))
+          val frange = ParquetFileRange(m.filename, low, j, None)
           curFileRanges = curFileRanges :+ frange
           val partition = VerticaDistributedFilesystemPartition(curFileRanges)
           partitions = partitions :+ partition
@@ -137,7 +138,8 @@ class VerticaDistributedFilesystemReadPipe(
         }
         else if(j == size - 1){ // Reached end of file's row groups, add to file ranges
           val rangeIdx = incrementRangeMapGetIndex(rangeCountMap, m.filename)
-          val frange = ParquetFileRange(m.filename, low, j, Some(rangeIdx))
+          //val frange = ParquetFileRange(m.filename, low, j, Some(rangeIdx))
+          val frange = ParquetFileRange(m.filename, low, j, None)
           curFileRanges = curFileRanges :+ frange
           i += 1
         }

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -262,8 +262,8 @@ class VerticaDistributedFilesystemReadPipe(
     // If there's an error, cleanup
     ret match {
       case Left(_) =>
-        logger.info("DISABLED: Cleaning up all files in path: " + hdfsPath)
-        //cleanupUtils.cleanupAll(fileStoreLayer, hdfsPath)
+        logger.info("Cleaning up all files in path: " + hdfsPath)
+        cleanupUtils.cleanupAll(fileStoreLayer, hdfsPath)
       case _ => ()
     }
     jdbcLayer.close()

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -114,15 +114,6 @@ class VerticaDistributedFilesystemReadPipe(
   }
 
   private def getPartitionInfo(fileMetadata: Seq[ParquetFileMetadata], rowGroupRoom: Int): PartitionInfo = {
-
-    /**
-     * TODO If true, cleanup information will be added to partitions, so nodes will perform a coordinated cleanup of
-     * exported parquet files.
-     *
-     * Temporarily set to false as an issue with the file cleanup system is investigated
-     */
-    val cleanup = false
-
     // Now, create partitions splitting up files roughly evenly
     var i = 0
     var partitions = List[VerticaDistributedFilesystemPartition]()
@@ -139,7 +130,7 @@ class VerticaDistributedFilesystemReadPipe(
         if(i == rowGroupRoom-1){ // Reached end of partition, cut off here
           val rangeIdx = incrementRangeMapGetIndex(rangeCountMap, m.filename)
 
-          val frange = ParquetFileRange(m.filename, low, j, if(cleanup) Some(rangeIdx) else None)
+          val frange = ParquetFileRange(m.filename, low, j, Some(rangeIdx))
 
           curFileRanges = curFileRanges :+ frange
           val partition = VerticaDistributedFilesystemPartition(curFileRanges)
@@ -152,7 +143,7 @@ class VerticaDistributedFilesystemReadPipe(
         }
         else if(j == size - 1){ // Reached end of file's row groups, add to file ranges
           val rangeIdx = incrementRangeMapGetIndex(rangeCountMap, m.filename)
-          val frange = ParquetFileRange(m.filename, low, j, if(cleanup) Some(rangeIdx) else None)
+          val frange = ParquetFileRange(m.filename, low, j, Some(rangeIdx))
           curFileRanges = curFileRanges :+ frange
           logger.debug("Reached end of file " + m.filename + " , range low: " +
             low + " , range high: " + j + " , idx: " + rangeIdx)

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -298,7 +298,7 @@ class VerticaDistributedFilesystemReadPipe(
   }
 
   private def getCleanupInfo(part: VerticaDistributedFilesystemPartition, curIdx: Int): Option[FileCleanupInfo] = {
-    logger.info("Getting cleanup info for partition with idx " + curIdx)
+    logger.debug("Getting cleanup info for partition with idx " + curIdx)
     for {
       _ <- if (curIdx >= part.fileRanges.size) {
         logger.warn("Invalid fileIdx " + this.fileIdx + ", can't perform cleanup.")

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -123,7 +123,7 @@ class VerticaDistributedFilesystemReadPipe(
     logger.info("Creating partitions.")
     for(m <- fileMetadata) {
       val size = m.rowGroupCount
-      logger.info("Splitting file " + m.filename + " with row group count " + size)
+      logger.debug("Splitting file " + m.filename + " with row group count " + size)
       var j = 0
       var low = 0
       while(j < size){
@@ -134,7 +134,7 @@ class VerticaDistributedFilesystemReadPipe(
           val partition = VerticaDistributedFilesystemPartition(curFileRanges)
           partitions = partitions :+ partition
           curFileRanges = List[ParquetFileRange]()
-          logger.info("Reached partition with file " + m.filename + " , range low: " +
+          logger.debug("Reached partition with file " + m.filename + " , range low: " +
             low + " , range high: " + j + " , idx: " + rangeIdx)
           i = 0
           low = j + 1
@@ -143,7 +143,7 @@ class VerticaDistributedFilesystemReadPipe(
           val rangeIdx = incrementRangeMapGetIndex(rangeCountMap, m.filename)
           val frange = ParquetFileRange(m.filename, low, j, Some(rangeIdx))
           curFileRanges = curFileRanges :+ frange
-          logger.info("Reached end of file " + m.filename + " , range low: " +
+          logger.debug("Reached end of file " + m.filename + " , range low: " +
             low + " , range high: " + j + " , idx: " + rangeIdx)
           i += 1
         }

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -262,8 +262,8 @@ class VerticaDistributedFilesystemReadPipe(
     // If there's an error, cleanup
     ret match {
       case Left(_) =>
-        logger.info("Cleaning up all files in path: " + hdfsPath)
-        cleanupUtils.cleanupAll(fileStoreLayer, hdfsPath)
+        logger.info("DISABLED: Cleaning up all files in path: " + hdfsPath)
+        //cleanupUtils.cleanupAll(fileStoreLayer, hdfsPath)
       case _ => ()
     }
     jdbcLayer.close()

--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -140,9 +140,6 @@ class HadoopFileStoreLayer(logProvider: LogProvider, schema: Option[StructType])
   private var writer: Option[ParquetWriter[InternalRow]] = None
   private var reader: Option[HadoopFileStoreReader] = None
 
-  // This variable is necessary for now until we change the interface's method of signalling when the read is done
-  private var done = false
-
   val hdfsConfig: Configuration = new Configuration()
   schema match {
     case Some(schema) =>
@@ -239,7 +236,6 @@ class HadoopFileStoreLayer(logProvider: LogProvider, schema: Option[StructType])
   }
 
   override def openReadParquetFile(file: ParquetFileRange): ConnectorResult[Unit] = {
-    this.done = false
     val filename = file.filename
 
     val readSupport = new ParquetReadSupport(
@@ -284,13 +280,7 @@ class HadoopFileStoreLayer(logProvider: LogProvider, schema: Option[StructType])
   }
 
   override def readDataFromParquetFile(blockSize: Int): ConnectorResult[DataBlock] = {
-    val dataBlock = for {
-      _ <- if (this.done) {
-        Left(DoneReading())
-      } else {
-        Right(())
-      }
-
+    for {
       dataBlock <- for {
           reader <- this.reader match {
             case Some(reader) => Right(reader)
@@ -301,15 +291,6 @@ class HadoopFileStoreLayer(logProvider: LogProvider, schema: Option[StructType])
         } yield dataBlock
 
     } yield dataBlock
-
-    dataBlock match {
-      case Left(_) => ()
-      case Right(block) => if (block.data.size < blockSize) {
-        this.done = true
-      }
-    }
-
-    dataBlock
   }
 
   override def closeReadParquetFile(): ConnectorResult[Unit] = {

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -115,8 +115,6 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
 
   private def handleConnectionException(e: Throwable): ConnectorError = {
     e match {
-      case e: java.sql.SQLSyntaxErrorException => SyntaxError(e)
-      case e: java.sql.SQLDataException => DataTypeError(e)
       case e: java.sql.SQLException => ConnectionSqlError(e)
       case e: Throwable => ConnectionError(e)
     }
@@ -126,12 +124,12 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
     * Gets a statement object or connection error if something is wrong.
     */
   private def getStatement: ConnectorResult[Statement] = {
-    this.connection.flatMap(conn => this.useConnection(conn, c => c.createStatement(), handleConnectionException)
+    this.connection.flatMap(conn => this.useConnection(conn, c => c.createStatement(), handleJDBCException)
       .left.map(_.context("getStatement: Error while trying to create statement.")))
   }
 
   private def getPreparedStatement(sql: String): ConnectorResult[PreparedStatement] = {
-    this.connection.flatMap(conn => this.useConnection(conn, c => c.prepareStatement(sql), handleConnectionException)
+    this.connection.flatMap(conn => this.useConnection(conn, c => c.prepareStatement(sql), handleJDBCException)
       .left.map(_.context("getPreparedStatement: Error while getting prepared statement.")))
   }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -115,10 +115,10 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
 
   private def handleConnectionException(e: Throwable): ConnectorError = {
     e match {
-      case e: java.sql.SQLException =>
-        ConnectionSqlError(e)
-      case e: Throwable =>
-        ConnectionError(e)
+      case e: java.sql.SQLSyntaxErrorException => SyntaxError(e)
+      case e: java.sql.SQLDataException => DataTypeError(e)
+      case e: java.sql.SQLException => ConnectionSqlError(e)
+      case e: Throwable => ConnectionError(e)
     }
   }
 

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -92,11 +92,11 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
     for {
       // Delete all portions
       _ <- (0 until fileCleanupInfo.fileRangeCount).map(idx => {
-        logger.info("Removing: " + recordFileName(filename, idx))
+        logger.debug("Removing: " + recordFileName(filename, idx))
         fileStoreLayer.removeFile(recordFileName(filename, idx))}).toList.sequence
 
       // Delete the original file
-      _ = logger.info("Removing parquet: " + filename)
+      _ = logger.debug("Removing parquet: " + filename)
       _ <- fileStoreLayer.removeFile(filename)
 
       // Delete the directory if empty
@@ -113,21 +113,22 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
       // Create the file for this portion
       _ <- fileStoreLayer.createFile(recordFileName(filename, fileCleanupInfo.fileIdx))
 
-      _ = logger.info("File: " + filename + "Checking file existance")
-      _ = logger.info("File: " + filename + "File idx: " + fileCleanupInfo.fileIdx)
-      _ = logger.info("File: " + filename + "File range count: " + fileCleanupInfo.fileRangeCount)
+      _ = logger.debug("File: " + filename + ", Checking file existance")
+      _ = logger.debug("File: " + filename + ", File idx: " + fileCleanupInfo.fileIdx)
+      _ = logger.debug("File: " + filename + ", File range count: " + fileCleanupInfo.fileRangeCount)
 
       // Check if all portions are written
       filesExist <- (0 until fileCleanupInfo.fileRangeCount).map(idx => {
-           logger.info("Checking existence: " + recordFileName(filename, idx))
+           logger.debug("Checking existence: " + recordFileName(filename, idx))
            fileStoreLayer.fileExists(recordFileName(filename, idx))
         }).toList.sequence
-      _ = logger.info("File: " + filename + "filesExist: " + filesExist.toString())
       allExist <- Right(filesExist.forall(x => x))
 
-      _ = logger.info("File: " + filename + "All exist: " + allExist)
+      _ = logger.debug("File: " + filename + ", filesExist: " + filesExist.toString())
+      _ = logger.debug("File: " + filename + ", All exist: " + allExist)
+
       _ <- if(allExist) {
-        logger.info("File: " + filename + "Performing cleanup")
+        logger.debug("File: " + filename + ", Performing cleanup")
         performCleanup(fileStoreLayer, fileCleanupInfo)
       } else Right(())
 

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -130,7 +130,9 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
       _ <- if(allExist) {
         logger.debug("File: " + filename + ", Performing cleanup")
         performCleanup(fileStoreLayer, fileCleanupInfo)
-      } else Right(())
+      } else {
+        Right(())
+      }
 
     } yield ()
   }

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -59,6 +59,7 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
 
   def cleanupAll(fileStoreLayer: FileStoreLayerInterface, path: String) : ConnectorResult[Unit] = {
     // Cleanup parent dir (unique id)
+    /*
     val p = new Path(s"$path")
     val parent = p.getParent
     if(parent != null) {
@@ -68,6 +69,8 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
     else {
       Left(CleanupError(path))
     }
+     */
+    Right(())
   }
 
   private def cleanupDirIfEmpty(fileStoreLayer: FileStoreLayerInterface, path: String): Either[ConnectorError, Unit]= {

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -111,6 +111,8 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
       // Create the file for this portion
       _ <- fileStoreLayer.createFile(recordFileName(filename, fileCleanupInfo.fileIdx))
 
+      _ = java.lang.Thread.sleep(2000L)
+
       // Check if all portions are written
       filesExist <- (0 until fileCleanupInfo.fileRangeCount).map(idx =>
           fileStoreLayer.fileExists(recordFileName(filename, idx))

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -119,13 +119,17 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
       _ = java.lang.Thread.sleep(20000L)
 
       _ = logger.info("Checking file existance")
+      _ = logger.info("File idx: " + fileCleanupInfo.fileIdx)
+      _ = logger.info("File range count: " + fileCleanupInfo.fileRangeCount)
 
       // Check if all portions are written
       filesExist <- (0 until fileCleanupInfo.fileRangeCount).map(idx =>
           fileStoreLayer.fileExists(recordFileName(filename, idx))
         ).toList.sequence
-      allExist <- Right(filesExist.forall(identity))
+      _ = logger.info("filesExist: " + filesExist.toString())
+      allExist <- Right(filesExist.forall(x => x))
 
+      _ = logger.info("All exist: " )
       _ <- if(allExist) {
         logger.info("Performing cleanup")
         performCleanup(fileStoreLayer, fileCleanupInfo)

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -116,10 +116,6 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
       // Create the file for this portion
       _ <- fileStoreLayer.createFile(recordFileName(filename, fileCleanupInfo.fileIdx))
 
-      _ = logger.info("File: " + filename + ", Sleeping")
-
-      _ = java.lang.Thread.sleep(20000L)
-
       _ = logger.info("File: " + filename + "Checking file existance")
       _ = logger.info("File: " + filename + "File idx: " + fileCleanupInfo.fileIdx)
       _ = logger.info("File: " + filename + "File range count: " + fileCleanupInfo.fileRangeCount)

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -94,8 +94,10 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
 
     for {
       // Delete all portions
-      _ <- (0 until fileCleanupInfo.fileRangeCount).map(idx =>
-          fileStoreLayer.removeFile(recordFileName(filename, idx))).toList.sequence
+      _ <- (0 until fileCleanupInfo.fileRangeCount).map(idx => {
+          logger.info("")
+          fileStoreLayer.removeFile(recordFileName(filename, idx)).toList.sequence
+      }
 
       // Delete the original file
       _ <- fileStoreLayer.removeFile(filename)
@@ -114,7 +116,7 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
       // Create the file for this portion
       _ <- fileStoreLayer.createFile(recordFileName(filename, fileCleanupInfo.fileIdx))
 
-      _ = java.lang.Thread.sleep(2000L)
+      _ = java.lang.Thread.sleep(20000L)
 
       // Check if all portions are written
       filesExist <- (0 until fileCleanupInfo.fileRangeCount).map(idx =>

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -114,7 +114,11 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
       // Create the file for this portion
       _ <- fileStoreLayer.createFile(recordFileName(filename, fileCleanupInfo.fileIdx))
 
+      _ = logger.info("Sleeping")
+
       _ = java.lang.Thread.sleep(20000L)
+
+      _ = logger.info("Checking file existance")
 
       // Check if all portions are written
       filesExist <- (0 until fileCleanupInfo.fileRangeCount).map(idx =>
@@ -122,7 +126,10 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
         ).toList.sequence
       allExist <- Right(filesExist.forall(identity))
 
-      _ <- if(allExist) performCleanup(fileStoreLayer, fileCleanupInfo) else Right(())
+      _ <- if(allExist) {
+        logger.info("Performing cleanup")
+        performCleanup(fileStoreLayer, fileCleanupInfo)
+      } else Right(())
 
     } yield ()
   }

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -59,7 +59,6 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
 
   def cleanupAll(fileStoreLayer: FileStoreLayerInterface, path: String) : ConnectorResult[Unit] = {
     // Cleanup parent dir (unique id)
-    /*
     val p = new Path(s"$path")
     val parent = p.getParent
     if(parent != null) {
@@ -69,8 +68,6 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
     else {
       Left(CleanupError(path))
     }
-     */
-    Right(())
   }
 
   private def cleanupDirIfEmpty(fileStoreLayer: FileStoreLayerInterface, path: String): Either[ConnectorError, Unit]= {

--- a/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/cleanup/CleanupUtils.scala
@@ -94,10 +94,8 @@ class CleanupUtils(logProvider: LogProvider) extends CleanupUtilsInterface {
 
     for {
       // Delete all portions
-      _ <- (0 until fileCleanupInfo.fileRangeCount).map(idx => {
-          logger.info("")
-          fileStoreLayer.removeFile(recordFileName(filename, idx)).toList.sequence
-      }
+      _ <- (0 until fileCleanupInfo.fileRangeCount).map(idx =>
+          fileStoreLayer.removeFile(recordFileName(filename, idx))).toList.sequence
 
       // Delete the original file
       _ <- fileStoreLayer.removeFile(filename)

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -554,7 +554,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     }
 
     pipe.readData match {
-      case Left(_) => fail
+      case Left(err) => fail(err.getFullContext)
       case Right(data) =>
         assert(data.data.isEmpty)
     }

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -470,6 +470,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     }
   }
 
+  /*
   it should "Use filestore layer to read data" in {
     val config = makeReadConfig
 
@@ -604,6 +605,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     pipe.readData
     pipe.endPartitionRead()
   }
+   */
 
   it should "Return an error if there is a partition type mismatch" in {
     val config = makeReadConfig

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -314,6 +314,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     }
   }
 
+  /* Disabled while cleanup is disabled
   it should "Split up files among partitions when they don't divide evenly" in {
     val partitionCount = 4
     val rowGroupPerFile = 5
@@ -359,6 +360,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
         assert(partitions(3).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(0) == ParquetFileRange(fname3,2,4,Some(1)))
     }
   }
+   */
 
 
   it should "Construct file range count map and pass include it in partitions" in {

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -351,12 +351,12 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
       case Right(partitionInfo) =>
         val partitions = partitionInfo.partitionSeq
         assert(partitions.length == partitionCount)
-        assert(partitions(0).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(0) == ParquetFileRange(fname1,0,3,None))
-        assert(partitions(1).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(0) == ParquetFileRange(fname1,4,4,None))
-        assert(partitions(1).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(1) == ParquetFileRange(fname2,0,2,None))
-        assert(partitions(2).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(0) == ParquetFileRange(fname2,3,4,None))
-        assert(partitions(2).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(1) == ParquetFileRange(fname3,0,1,None))
-        assert(partitions(3).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(0) == ParquetFileRange(fname3,2,4,None))
+        assert(partitions(0).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(0) == ParquetFileRange(fname1,0,3,Some(0)))
+        assert(partitions(1).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(0) == ParquetFileRange(fname1,4,4,Some(1)))
+        assert(partitions(1).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(1) == ParquetFileRange(fname2,0,2,Some(0)))
+        assert(partitions(2).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(0) == ParquetFileRange(fname2,3,4,Some(1)))
+        assert(partitions(2).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(1) == ParquetFileRange(fname3,0,1,Some(0)))
+        assert(partitions(3).asInstanceOf[VerticaDistributedFilesystemPartition].fileRanges(0) == ParquetFileRange(fname3,2,4,Some(1)))
     }
   }
 

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -161,7 +161,7 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
       case Right(u) => assert(false) // should not succeed
       case Left(err) => {
         assert(err.getError match {
-          case SyntaxError(_) => true
+          case _: SyntaxError => true
           case _ => false
         })
       }
@@ -175,7 +175,7 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
       case Right(u) => assert(false) // should not succeed
       case Left(err) => {
         assert(err.getError match {
-          case ConnectionError() => true
+          case _: ConnectionError => true
           case _ => false
         })
       }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -18,7 +18,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import com.vertica.spark.datasource.jdbc._
 import com.vertica.spark.config.JDBCConfig
-import com.vertica.spark.util.error.{ConnectionError, DataTypeError, SyntaxError}
+import com.vertica.spark.util.error.{ConnectionSqlError, DataTypeError, SyntaxError}
 
 /**
   * Tests basic functionality of the VerticaJdbcLayer
@@ -176,8 +176,9 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
     badJdbcLayer.execute("CREATE TABLE " + tablename + "(name integer);") match {
       case Right(u) => assert(false) // should not succeed
       case Left(err) => {
+        println(err.getFullContext)
         assert(err.getError match {
-          case _: ConnectionError => true
+          case _: ConnectionSqlError => true
           case _ => false
         })
       }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -133,6 +133,7 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
         assert(false)
       }
       case Left(err) => {
+        println(err.getError.getFullContext)
         assert(err.getError match {
           case SyntaxError(_) => true
           case _ => false
@@ -148,6 +149,7 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
     jdbcLayer.execute("INSERT INTO " + tablename + " VALUES('abc123');") match {
       case Right(u) => assert(false) // should not succeed
       case Left(err) => {
+        println(err.getError.getFullContext)
         assert(err.getError match {
           case DataTypeError(_) => true
           case _ => false


### PR DESCRIPTION
### Summary

Fixed read logic to properly read multiple file ranges in a partition.

### Description

There was a logical issue in the read pipe, where it expected a "Done Reading" Error type when a file range was done reading.  It would instead simply receive an empty data block. The logic for setting a flag and then returning a "done reading" error is now eliminated.

Also made a change so that if cleanup files get left over due to some problem, they will not cause an issue for the next read attempt.

### Related Issue

VER-76600

### Additional Reviewers

@jonathanl-bq 
@NerdLogic 