### PR TITLE
Add spark dependencies to examples

### DIFF
--- a/examples/basic-read/build.sbt
+++ b/examples/basic-read/build.sbt
@@ -20,3 +20,5 @@ resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies += "com.typesafe" % "config" % "1.4.1"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "3.0.0"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.0.0"

--- a/examples/basic-write/build.sbt
+++ b/examples/basic-write/build.sbt
@@ -20,3 +20,5 @@ resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies += "com.typesafe" % "config" % "1.4.1"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "3.0.0"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.0.0"


### PR DESCRIPTION
### Summary

Add spark dependencies to examples

### Description

These dependencies were removed from the connector JAR, and are now required by any project using spark + the connector.

### Additional Reviewers

@jonathanl-bq 