### PR TITLE
VER-76615: Fix session leakage +  remove unnecessary connections

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSWriter.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSWriter.scala
@@ -83,10 +83,9 @@ class DSWriter(config: WriteConfig, uniqueId: String, pipeFactory: VerticaPipeFa
 
   def closeWrite(): ConnectorResult[Unit] = {
     if(data.nonEmpty) {
-      for {
-        _ <- pipe.writeData(DataBlock(data))
-        _ <- pipe.endPartitionWrite()
-      } yield ()
+       val ret = pipe.writeData(DataBlock(data))
+       pipe.endPartitionWrite()
+       ret
     }
     else {
       pipe.endPartitionWrite()

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -266,6 +266,8 @@ class VerticaDistributedFilesystemReadPipe(
       rowGroupRoom = (totalRowGroups / partitionCount) + extraSpace
 
       partitionInfo = getPartitionInfo(fileMetadata, rowGroupRoom)
+
+      _ <- jdbcLayer.close()
     } yield partitionInfo
 
     // If there's an error, cleanup
@@ -273,9 +275,10 @@ class VerticaDistributedFilesystemReadPipe(
       case Left(_) =>
         logger.info("Cleaning up all files in path: " + hdfsPath)
         cleanupUtils.cleanupAll(fileStoreLayer, hdfsPath)
+        jdbcLayer.close()
       case _ => ()
     }
-    jdbcLayer.close()
+
     ret
   }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -402,8 +402,6 @@ class VerticaDistributedFilesystemReadPipe(
    */
   def endPartitionRead(): ConnectorResult[Unit] = {
     logger.info("Ending partition read.")
-
-    jdbcLayer.close()
     fileStoreLayer.closeReadParquetFile()
   }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -72,7 +72,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
    * - Creates the directory that files will be exported to
    */
   def doPreWriteSteps(): ConnectorResult[Unit] = {
-    val ret = for {
+    for {
       // Check if schema is valid
       _ <- checkSchemaForDuplicates(config.schema)
 
@@ -102,13 +102,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
 
       // Create job status table / entry
       _ <- tableUtils.createAndInitJobStatusTable(config.tablename, config.jdbcConfig.username, config.sessionId, if(config.isOverwrite) "OVERWRITE" else "APPEND")
-
-      _ <- jdbcLayer.close()
     } yield ()
-
-    // Safety check upon failure; make sure to close connection
-    jdbcLayer.close()
-    ret
   }
 
   def startPartitionWrite(uniqueId: String): ConnectorResult[Unit] = {

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -124,13 +124,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
   }
 
   def endPartitionWrite(): ConnectorResult[Unit] = {
-    val ret1 = jdbcLayer.close()
-    val ret2 = fileStoreLayer.closeWriteParquetFile()
-    (ret1, ret2) match {
-      case (Left(_), _) => ret1
-      case (_, Left(_)) => ret2
-      case (_, _) => Right(())
-    }
+    fileStoreLayer.closeWriteParquetFile()
   }
 
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -102,7 +102,7 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
   private val jdbcURI = "jdbc:vertica://" + cfg.host + ":" + cfg.port + "/" + cfg.db
   logger.info("Connecting to Vertica with URI: " + jdbcURI)
 
-  private val connection: ConnectorResult[Connection] = {
+  private lazy val connection: ConnectorResult[Connection] = {
     Try { DriverManager.getConnection(jdbcURI, prop) }
       .toEither.left.map(handleConnectionException)
       .flatMap(conn =>

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -484,7 +484,6 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (fileStoreLayer.closeReadParquetFile _).expects().returning(Right())
 
     val jdbcLayer = mock[JdbcLayerInterface]
-    (jdbcLayer.close _).expects().returning(Right(()))
 
     val pipe = new VerticaDistributedFilesystemReadPipe(config, fileStoreLayer, jdbcLayer, mock[SchemaToolsInterface], mock[CleanupUtilsInterface], dataSize = 2)
 
@@ -528,7 +527,6 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (fileStoreLayer.closeReadParquetFile _).expects().returning(Right())
 
     val jdbcLayer = mock[JdbcLayerInterface]
-    (jdbcLayer.close _).expects().returning(Right(()))
 
     val pipe = new VerticaDistributedFilesystemReadPipe(config, fileStoreLayer, jdbcLayer, mock[SchemaToolsInterface], mock[CleanupUtilsInterface], dataSize = 2)
 
@@ -579,7 +577,6 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     val partition = VerticaDistributedFilesystemPartition(List(fileRange1, fileRange2), Some(Map(filename1 -> 1, filename2 -> 1)))
 
     val jdbcLayer = mock[JdbcLayerInterface]
-    (jdbcLayer.close _).expects().returning(Right(()))
 
     val fileStoreLayer = mock[FileStoreLayerInterface]
     (fileStoreLayer.openReadParquetFile _).expects(fileRange1).returning(Right())
@@ -678,7 +675,6 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (fileStoreLayer.closeReadParquetFile _).expects().returning(Left(StagingFsUrlMissingError()))
 
     val jdbcLayer = mock[JdbcLayerInterface]
-    (jdbcLayer.close _).expects().returning(Right(()))
 
     val pipe = new VerticaDistributedFilesystemReadPipe(config, fileStoreLayer, jdbcLayer, mock[SchemaToolsInterface], mock[CleanupUtilsInterface])
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -71,7 +71,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
-    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.createDir _).expects(*).returning(Right(()))
@@ -97,7 +96,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     config.setOverwrite(true)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
-    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.createDir _).expects(*).returning(Right(()))
@@ -125,7 +123,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = Some(createTableStatement), copyColumnList = None, sessionId = "id", 0.0f)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
-    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
 
@@ -150,7 +147,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
-    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
@@ -174,7 +170,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
-    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
 
@@ -200,7 +195,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
-    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -225,7 +225,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val uniqueId = "unique-id"
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
-    (jdbcLayerInterface.close _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -71,6 +71,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.createDir _).expects(*).returning(Right(()))
@@ -96,6 +97,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     config.setOverwrite(true)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.createDir _).expects(*).returning(Right(()))
@@ -123,6 +125,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = Some(createTableStatement), copyColumnList = None, sessionId = "id", 0.0f)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
 
@@ -147,6 +150,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
+
     val schemaToolsInterface = mock[SchemaToolsInterface]
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
 
@@ -169,6 +174,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
+
     val schemaToolsInterface = mock[SchemaToolsInterface]
 
     // Directory w/ configured address is created
@@ -188,6 +195,29 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     tryDoPreWriteSteps(pipe)
   }
 
+  it should "error if view exists with the table name" in {
+    val schema = new StructType(Array(StructField("col1", IntegerType)))
+    val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
+
+    val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.close _).expects().returning(Right()).anyNumberOfTimes()
+
+    val schemaToolsInterface = mock[SchemaToolsInterface]
+
+    val fileStoreLayerInterface = mock[FileStoreLayerInterface]
+
+    val tableUtils = mock[TableUtilsInterface]
+    (tableUtils.tableExists _).expects(*).returning(Right(false))
+    (tableUtils.viewExists _).expects(*).returning(Right(true))
+
+    val pipe = new VerticaDistributedFilesystemWritePipe(config, fileStoreLayerInterface, jdbcLayerInterface, schemaToolsInterface, tableUtils)
+
+    pipe.doPreWriteSteps() match {
+      case Left(err) => assert(err.getError == ViewExistsError())
+      case Right(_) => fail
+    }
+  }
+
   it should "use filestore layer to write data" in {
     val schema = new StructType(Array(StructField("col1", IntegerType)))
     val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
@@ -196,6 +226,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.close _).expects().returning(Right(()))
+
     val schemaToolsInterface = mock[SchemaToolsInterface]
 
     val v1: Int = 1
@@ -239,28 +270,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
         case OpenWriteError(_) => true
         case _ => false
       })
-    }
-  }
-
-  it should "error if view exists with the table name" in {
-    val schema = new StructType(Array(StructField("col1", IntegerType)))
-    val config = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig, tablename = tablename, schema = schema, strlen = strlen, targetTableSql = None, copyColumnList = None, sessionId = "id", 0.0f)
-
-    val jdbcLayerInterface = mock[JdbcLayerInterface]
-
-    val schemaToolsInterface = mock[SchemaToolsInterface]
-
-    val fileStoreLayerInterface = mock[FileStoreLayerInterface]
-
-    val tableUtils = mock[TableUtilsInterface]
-    (tableUtils.tableExists _).expects(*).returning(Right(false))
-    (tableUtils.viewExists _).expects(*).returning(Right(true))
-
-    val pipe = new VerticaDistributedFilesystemWritePipe(config, fileStoreLayerInterface, jdbcLayerInterface, schemaToolsInterface, tableUtils)
-
-    pipe.doPreWriteSteps() match {
-      case Left(err) => assert(err.getError == ViewExistsError())
-      case Right(_) => fail
     }
   }
 

--- a/examples/looped/build.sbt
+++ b/examples/looped/build.sbt
@@ -1,0 +1,24 @@
+// (c) Copyright [2020-2021] Micro Focus or one of its affiliates.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+scalaVersion := "2.12.12"
+name := "spark-vertica-connector-functional-tests"
+organization := "com.vertica"
+version := "1.0"
+
+resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
+resolvers += "jitpack" at "https://jitpack.io"
+
+libraryDependencies += "com.typesafe" % "config" % "1.4.1"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "3.0.0"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.0.0"

--- a/examples/looped/src/main/resources/application.conf
+++ b/examples/looped/src/main/resources/application.conf
@@ -1,0 +1,11 @@
+functional-tests {
+  host="eng-g9-051"
+  port=5433
+  db="testdb"
+  user="release"
+  password=""
+  log=true
+  filepath="hdfs://localhost:8020/data/"
+  dirpath="hdfs://localhost:8020/data/dirtest/"
+}
+

--- a/examples/looped/src/main/scala/example/Main.scala
+++ b/examples/looped/src/main/scala/example/Main.scala
@@ -39,10 +39,18 @@ object Main extends App {
 
   try {
     val tableName = "dftest"
-    val schema = new StructType(Array(StructField("col1", IntegerType)))
+    val rows = sc.parallelize(Array(
+                                Row(1,"hello", true),
+                                Row(2,"goodbye", false)
+                              ))
 
-    val data = Seq(Row(77))
-    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+    val schema = StructType(Array(
+                              StructField("id",IntegerType, false),
+                              StructField("message",StringType,true),
+                              StructField("still_here",BooleanType,true)
+                            ))
+
+    val df = spark.createDataFrame(rows, schema)
     println(df.toString())
     val mode = SaveMode.Append
 

--- a/examples/looped/src/main/scala/example/Main.scala
+++ b/examples/looped/src/main/scala/example/Main.scala
@@ -1,0 +1,57 @@
+// (c) Copyright [2020-2021] Micro Focus or one of its affiliates.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package example
+
+import java.sql.Connection
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.Config
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+
+object Main extends App {
+  val conf: Config = ConfigFactory.load()
+
+  val writeOpts = Map(
+    "host" -> conf.getString("functional-tests.host"),
+    "user" -> conf.getString("functional-tests.user"),
+    "db" -> conf.getString("functional-tests.db"),
+    "staging_fs_url" -> conf.getString("functional-tests.filepath"),
+    "password" -> conf.getString("functional-tests.password"),
+    "logging_level" -> {if(conf.getBoolean("functional-tests.log")) "DEBUG" else "OFF"}
+  )
+
+  val spark = SparkSession.builder()
+    .master("local[*]")
+    .appName("Vertica Connector Test Prototype")
+    .getOrCreate()
+
+  try {
+    val tableName = "dftest"
+    val schema = new StructType(Array(StructField("col1", IntegerType)))
+
+    val data = Seq(Row(77))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+    println(df.toString())
+    val mode = SaveMode.Append
+
+    for(i <- 0 until 100) {
+      println("Iteration: " + i)
+      df.write.format("com.vertica.spark.datasource.VerticaSource").options(writeOpts + ("table" -> tableName)).mode(mode).save()
+    }
+
+  } finally {
+    spark.close()
+  }
+}

--- a/examples/looped/src/main/scala/example/Main.scala
+++ b/examples/looped/src/main/scala/example/Main.scala
@@ -17,7 +17,7 @@ import java.sql.Connection
 
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.Config
-import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType, BooleanType, StringType}
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 
 object Main extends App {

--- a/examples/looped/src/main/scala/example/Main.scala
+++ b/examples/looped/src/main/scala/example/Main.scala
@@ -39,7 +39,7 @@ object Main extends App {
 
   try {
     val tableName = "dftest"
-    val rows = sc.parallelize(Array(
+    val rows = spark.sparkContext.parallelize(Array(
                                 Row(1,"hello", true),
                                 Row(2,"goodbye", false)
                               ))

--- a/examples/looped/src/main/scala/example/TestUtils.scala
+++ b/examples/looped/src/main/scala/example/TestUtils.scala
@@ -1,0 +1,110 @@
+// (c) Copyright [2020-2021] Micro Focus or one of its affiliates.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package example
+
+import java.sql.{Connection, DriverManager, Statement}
+import java.util.Properties
+import org.apache.spark.sql.SparkSession
+
+object TestUtils {
+  def getJDBCConnection(host: String, port: Int = 5433, db: String, user: String, password: String): Connection = {
+    Class.forName("com.vertica.jdbc.Driver").newInstance()
+
+    val prop = new Properties()
+    prop.put("user", user)
+    prop.put("password", password)
+
+    getConnectionByProp(host, port, db, prop)(None)
+  }
+
+  def getJDBCUrl(host: String, port: Int = 5433, db: String): String = {
+    "jdbc:vertica://" + host + ":" + port + "/" + db
+  }
+
+  def getConnectionByProp(host: String, port: Int = 5433, db: String, prop: Properties)(overrideHost: Option[String]): Connection = {
+    Class.forName("com.vertica.jdbc.Driver").newInstance()
+
+    val h = overrideHost match {
+      case Some(m) => m
+      case None    => host
+    }
+    prop.setProperty("host", h)
+    val jdbcURI = getJDBCUrl(h, port, db)
+    DriverManager.getConnection(jdbcURI, prop)
+
+  }
+
+  def createTableBySQL(conn: Connection, tableName: String, createTableStr: String): Boolean = {
+    val stmt = conn.createStatement()
+
+    stmt.execute("drop table if exists " + tableName)
+    println(createTableStr)
+    stmt.execute(createTableStr)
+  }
+
+  def createTable(conn: Connection, tableName: String, isSegmented: Boolean = true, numOfRows: Int = 10): Unit = {
+    val stmt = conn.createStatement()
+    stmt.execute("drop table if exists " + tableName)
+    val createStr = "create table " + tableName + "(a int, b int) " +
+      (if (isSegmented) "segmented by hash(a)" else "unsegmented") + " all nodes;"
+    println(createStr)
+    stmt.execute(createStr)
+    populateTable(stmt, tableName, numOfRows)
+  }
+
+  private def populateTable(stmt: Statement, tableName: String, numOfRows: Int) {
+    for (i <- 0 until numOfRows) {
+      val insertStr = "insert into " + tableName + " values (" + i + " ," + i + ")"
+      println(insertStr)
+      stmt.execute(insertStr)
+    }
+  }
+
+  def populateTableBySQL(stmt: Statement, insertStr: String, numOfRows: Int) {
+    for (_ <- 0 until numOfRows) {
+      stmt.execute(insertStr)
+    }
+  }
+
+  def doCount(spark: SparkSession, opt:Map[String, String]):Long = {
+    val df = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(opt).load()
+
+    df.cache()
+    df.show()
+    println("schema =" + df.schema)
+    val c = df.count()
+    println("count = " + c)
+    c
+  }
+
+  def createTablePartialNodes(conn: Connection, tableName: String, isSegmented: Boolean = true, numOfRows: Int = 10, nodes: List[String]): Unit = {
+    val stmt = conn.createStatement()
+    stmt.execute("drop table if exists " + tableName)
+    val createStr = "create table if not exists " + tableName + "(a int, b int) " +
+      (if (isSegmented) "segmented by hash(a)" + " nodes " + nodes.mkString(",")
+      else " UNSEGMENTED node " + nodes.head + " KSAFE 0") + ";"
+    println(createStr)
+    stmt.execute(createStr)
+    populateTable(stmt, tableName, numOfRows)
+  }
+
+  def getNodeNames(conn: Connection): List[String] = {
+    val nodeQry = "select node_name from nodes;"
+    val rs = conn.createStatement().executeQuery(nodeQry)
+    new Iterator[String] {
+      def hasNext: Boolean = rs.next()
+      def next(): String = rs.getString(1)
+    }.toList
+  }
+}


### PR DESCRIPTION
### Summary

Fix session leakage + remove unnecessary connections

### Description

Because of how our JDBC layer was being used as a dependency, it was opening connections that were not actually necessary. This fixes this by making the connection a lazy val, initiated once it's needed.

### Related Issue

VER-76615

### Additional Reviewers

@jonathanl-bq 
@NerdLogic 