### PR TITLE
VER-76601: Calendar Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,29 +123,3 @@ Below is a detailed list of connector options:
 
 The connector supports basic Spark types. Complex types are not currently supported.
 
-
-## Known Issues
-
-### Old timestamps
-
-If using very old dates and timestamps, you may run into an error like the following:
-
-```
-org.apache.spark.SparkUpgradeException: You may get a different result due to the upgrading of Spark 3.0: writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z into Parquet files can be dangerous, as the files may be read by Spark 2.x or legacy versions of Hive later, which uses a legacy hybrid calendar that is different from Spark 3.0+'s Proleptic Gregorian calendar. See more details in SPARK-31404. You can set spark.sql.legacy.parquet.datetimeRebaseModeInWrite to 'LEGACY' to rebase the datetime values w.r.t. the calendar difference during writing, to get maximum interoperability. Or set spark.sql.legacy.parquet.datetimeRebaseModeInWrite to 'CORRECTED' to write the datetime values as it is, if you are 100% sure that the written files will only be read by Spark 3.0+ or other systems that use Proleptic Gregorian calendar.
-```
-
-### Database connection limit after many writes
-
-Upon performing many operations writing from Spark to Vertica, you may see an error with this as a root cause:
-
-```
-[Vertica][VJDBC](4060) FATAL: New session rejected due to limit, already 55 sessions active
-```
-
-A potential workaround in the short term can be upping the session limit:
-
-```
-SELECT SET_CONFIG_PARAMETER ('MaxClientSessions', 100);
-```
-
-However, this will simply delay the problem from arising. A solution to the issue is being looked into.

--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -152,6 +152,8 @@ class HadoopFileStoreLayer(logProvider: LogProvider, schema: Option[StructType])
   hdfsConfig.set(SQLConf.PARQUET_INT96_AS_TIMESTAMP.key, "true")
   hdfsConfig.set(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, "false")
   hdfsConfig.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "INT96")
+  hdfsConfig.set(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE.key, "CORRECTED")
+  hdfsConfig.set(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_READ.key, "CORRECTED")
 
 
   private class VerticaParquetBuilder(file: Path) extends ParquetWriter.Builder[InternalRow, VerticaParquetBuilder](file: Path) {

--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -155,6 +155,13 @@ class HadoopFileStoreLayer(logProvider: LogProvider, schema: Option[StructType])
   hdfsConfig.set(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE.key, "CORRECTED")
   hdfsConfig.set(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_READ.key, "CORRECTED")
 
+  /**
+   * Set spark conf for handling old dates if unset
+   */
+  if(LegacyBehaviorPolicy.withName(
+      SQLConf.get.getConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE)) == LegacyBehaviorPolicy.EXCEPTION) {
+      SQLConf.get.setConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE, "CORRECTED")
+    }
 
   private class VerticaParquetBuilder(file: Path) extends ParquetWriter.Builder[InternalRow, VerticaParquetBuilder](file: Path) {
     override protected def self: VerticaParquetBuilder = this

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -3087,7 +3087,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   */
 
   it should "Verify writing old dateType works" in {
-    val tableName = "s2vdevtest35"
+    val tableName = "s2vdevtestoldwrite"
     val schema = StructType(StructField("dt", DateType, nullable=true)::Nil)
 
     // jeff
@@ -3132,11 +3132,11 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
       stmt.close()
     }
     assert ( rowsLoaded == numDfRows )
-    TestUtils.dropTable(conn, tableName)
+    //TestUtils.dropTable(conn, tableName)
   }
 
   it should "Verify writing old timestamp type works" in {
-    val tableName = "s2vdevtest35"
+    val tableName = "s2vdevtestoldwritetime"
     val schema = StructType(StructField("dt", TimestampType, nullable=true)::Nil)
 
     val timestampInMicros = System.currentTimeMillis() * 1000
@@ -3171,6 +3171,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
       stmt.close()
     }
     assert ( rowsLoaded == numDfRows )
-    TestUtils.dropTable(conn, tableName)
+    //TestUtils.dropTable(conn, tableName)
   }
 }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -52,8 +52,8 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     assert(df.count() == 1)
     df.rdd.foreach(row => assert(row.getAs[Long](0) == 2))
+    TestUtils.dropTable(conn, tableName1)
   }
-  /*
 
   it should "read 20 rows of data from Vertica" in {
     val tableName1 = "dftest1"
@@ -68,6 +68,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     assert(df.count() == 20)
     df.rdd.foreach(row => assert(row.getAs[Long](0) == 2))
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "perform aggregations" in {
@@ -87,6 +88,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     assert(sumDf.head.get(0) == 2*n + 4*n)
     assert(sumDf.head.get(1) == 5)
     assert(sumDf.head.get(2) == 7)
+    TestUtils.dropTable(conn, tableName1)
   }
 
 
@@ -117,6 +119,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val joined_df = df_as1.join(
       df_as2, col("df1.a") === col("df2.b"), "inner")
     assert(joined_df.collect().length == n*n)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "collect results" in {
@@ -135,6 +138,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val arr = df.collect()
 
     assert(arr.length == n*2)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "return column names" in {
@@ -154,6 +158,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     assert(cols(0) == "a")
     assert(cols(1) == "b")
     assert(cols(2) == "c")
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "sort" in {
@@ -174,6 +179,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     assert(df.sort("a").head.get(1) == 3)
     assert(df.sort("b").head.get(0) == 5)
     assert(df.sort("c").head.get(0) == 3)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "get distinct elements" in {
@@ -192,6 +198,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val df: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(readOpts + ("table" -> tableName1)).load()
 
     assert(df.distinct().count() == 3)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "drop and take" in {
@@ -211,6 +218,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     val dfMinusCols = df.drop("a").drop("c")
     assert(dfMinusCols.distinct().sort("b").take(1)(0).get(0) == 2)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "support data frame schema" in {
@@ -230,6 +238,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val sc = StructType(Array(StructField("a",LongType,nullable = true), StructField("b",DoubleType,nullable = true)))
 
     assert(schema.toString equals sc.toString)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "support data frame projection" in {
@@ -247,6 +256,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     assert(count == n)
     assert(filtered.columns.mkString equals Array("a").mkString)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "support data frame filter" in {
@@ -265,6 +275,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val count = filtered.count()
 
     assert(count == n)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "load data from Vertica table that is [SEGMENTED] on [ALL] nodes" in {
@@ -276,6 +287,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val r = TestUtils.doCount(spark, readOpts + ("table" -> tableName1))
 
     assert(r == n)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "load data from Vertica table that is [UNSEGMENTED] on [ALL] nodes" in {
@@ -287,6 +299,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val r = TestUtils.doCount(spark, readOpts + ("table" -> tableName1))
 
     assert(r == n)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "load data from Vertica table that is [SEGMENTED] on [SOME] nodes for [arbitrary partition number]" in {
@@ -301,6 +314,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
       val r = TestUtils.doCount(spark, readOpts + ("table" -> tableName1))
       assert(r == n)
     }
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "load data from Vertica table that is [SEGMENTED] on [Some] nodes" in {
@@ -312,6 +326,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val r = TestUtils.doCount(spark, readOpts + ("table" -> tableName1))
 
     assert(r == n)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "load data from Vertica table that is [UNSEGMENTED] on [Some] nodes" in {
@@ -323,6 +338,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val r = TestUtils.doCount(spark, readOpts + ("table" -> tableName1))
 
     assert(r == n)
+    TestUtils.dropTable(conn, tableName1)
   }
 
   it should "load data from Vertica table that is [UNSEGMENTED] on [One] nodes for [arbitrary partition number]" in {
@@ -2983,6 +2999,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     }
     assert (failureMessage.nonEmpty)
     TestUtils.dropTable(conn, tableName)
+    TestUtils.dropTable(conn, "peopleTable")
   }
 
   it should "fail to save a DF if there are syntax errors in target_table_ddl" in {
@@ -3084,7 +3101,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     assert (failureMessage.nonEmpty)
     TestUtils.dropTable(conn, tableName)
   }
-  */
 
   it should "Verify writing old dateType works" in {
     val tableName = "s2vdevtestoldwrite"
@@ -3132,7 +3148,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
       stmt.close()
     }
     assert ( rowsLoaded == numDfRows )
-    //TestUtils.dropTable(conn, tableName)
+    TestUtils.dropTable(conn, tableName)
   }
 
   it should "Verify writing old timestamp type works" in {
@@ -3171,6 +3187,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
       stmt.close()
     }
     assert ( rowsLoaded == numDfRows )
-    //TestUtils.dropTable(conn, tableName)
+    TestUtils.dropTable(conn, tableName)
   }
 }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -53,6 +53,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     assert(df.count() == 1)
     df.rdd.foreach(row => assert(row.getAs[Long](0) == 2))
   }
+  /*
 
   it should "read 20 rows of data from Vertica" in {
     val tableName1 = "dftest1"
@@ -3081,6 +3082,95 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
       case e: java.lang.Exception => failureMessage = e.toString
     }
     assert (failureMessage.nonEmpty)
+    TestUtils.dropTable(conn, tableName)
+  }
+  */
+
+  it should "Verify writing old dateType works" in {
+    val tableName = "s2vdevtest35"
+    val schema = StructType(StructField("dt", DateType, nullable=true)::Nil)
+
+    // jeff
+    val c = java.util.Calendar.getInstance()
+    c.set(1822,1,1, 1,1,1)
+    val ms = new java.util.Date(c.getTimeInMillis)
+
+    //hua
+    val date1 = new java.text.SimpleDateFormat("yyyy-MM-dd").parse("1555-07-05")
+    val date3 = new java.text.SimpleDateFormat("yyyy-MM-dd").parse("0455-01-01")
+
+    val inputData = Seq(
+      new java.sql.Date(date1.getTime),
+      new java.sql.Date(date3.getTime),
+      new java.sql.Date(ms.getTime),
+      null
+    )
+    val rowRDD = spark.sparkContext.parallelize(inputData).map(p => Row(p))
+    val df = spark.createDataFrame(rowRDD, schema)
+    df.show
+    df.schema
+    val numDfRows = df.count()
+
+    val stmt = conn.createStatement()
+    stmt.execute("DROP TABLE IF EXISTS "+ tableName)
+    TestUtils.createTableBySQL(conn, tableName, "CREATE TABLE " + tableName + " (a date)")
+
+    val options = writeOpts + ("table" -> tableName)
+
+    val mode = SaveMode.Overwrite
+    df.write.format("com.vertica.spark.datasource.VerticaSource").options(options).mode(mode).save()
+
+    var rowsLoaded = 0
+    val query = "SELECT COUNT(*) AS cnt FROM \"" + options("table") + "\""
+    try {
+      val rs = stmt.executeQuery(query)
+      if (rs.next) {
+        rowsLoaded = rs.getInt("cnt")
+      }
+    }
+    finally {
+      stmt.close()
+    }
+    assert ( rowsLoaded == numDfRows )
+    TestUtils.dropTable(conn, tableName)
+  }
+
+  it should "Verify writing old timestamp type works" in {
+    val tableName = "s2vdevtest35"
+    val schema = StructType(StructField("dt", TimestampType, nullable=true)::Nil)
+
+    val timestampInMicros = System.currentTimeMillis() * 1000
+
+    val inputData = Seq(
+      Timestamp.valueOf("1855-01-01 23:00:01")
+    )
+    val rowRDD = spark.sparkContext.parallelize(inputData).map(p => Row(p))
+    val df = spark.createDataFrame(rowRDD, schema)
+    df.show
+    df.schema
+    val numDfRows = df.count()
+
+    val stmt = conn.createStatement()
+    stmt.execute("DROP TABLE IF EXISTS "+ tableName)
+    TestUtils.createTableBySQL(conn, tableName, "CREATE TABLE " + tableName + " (a timestamp)")
+
+    val options = writeOpts + ("table" -> tableName)
+
+    val mode = SaveMode.Overwrite
+    df.write.format("com.vertica.spark.datasource.VerticaSource").options(options).mode(mode).save()
+
+    var rowsLoaded = 0
+    val query = "SELECT COUNT(*) AS cnt FROM \"" + options("table") + "\""
+    try {
+      val rs = stmt.executeQuery(query)
+      if (rs.next) {
+        rowsLoaded = rs.getInt("cnt")
+      }
+    }
+    finally {
+      stmt.close()
+    }
+    assert ( rowsLoaded == numDfRows )
     TestUtils.dropTable(conn, tableName)
   }
 }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -2208,12 +2208,10 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val tableName = "s2vdevtest35"
     val schema = StructType(StructField("dt", DateType, nullable=true)::Nil)
 
-    // jeff
     val c = java.util.Calendar.getInstance()
     c.set(1965,1,1, 1,1,1)
     val ms = new java.util.Date(c.getTimeInMillis)
 
-    //hua
     val date1 = new java.text.SimpleDateFormat("yyyy-MM-dd").parse("2016-07-05")
     val date3 = new java.text.SimpleDateFormat("yyyy-MM-dd").parse("1999-01-01")
 
@@ -3106,12 +3104,10 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val tableName = "s2vdevtestoldwrite"
     val schema = StructType(StructField("dt", DateType, nullable=true)::Nil)
 
-    // jeff
     val c = java.util.Calendar.getInstance()
     c.set(1822,1,1, 1,1,1)
     val ms = new java.util.Date(c.getTimeInMillis)
 
-    //hua
     val date1 = new java.text.SimpleDateFormat("yyyy-MM-dd").parse("1555-07-05")
     val date3 = new java.text.SimpleDateFormat("yyyy-MM-dd").parse("0455-01-01")
 


### PR DESCRIPTION
### Summary

Fix calendar compatibility error.

### Description

Set setting to use new spark calendar system, based on gregorian calendar. This should be fine since Vertica does not use the old mixed calendar that older versions of spark used.

+ Small modifications to integration tests

### Related Issue

VER-76601

### Additional Reviewers

@jonathanl-bq 
@NerdLogic 