### PR TITLE
Add Unit Tests to V2 API classes

### DIFF
--- a/connector/build.sbt
+++ b/connector/build.sbt
@@ -43,9 +43,7 @@ import sbtsonar.SonarPlugin.autoImport.sonarProperties
 
 sonarProperties ++= Map(
   "sonar.host.url" -> "http://localhost:80",
-  "sonar.coverage.exclusions" -> "**/*FileStoreLayerInterface.scala,**/*VerticaJdbcLayer.scala"
 )
-
 
 scapegoatVersion in ThisBuild := "1.3.3"
 scapegoatReports := Seq("xml")
@@ -55,8 +53,13 @@ scalacOptions += "-Ypartial-unification"
 scalastyleFailOnError := true
 scalastyleFailOnWarning := true
 
-coverageExcludedPackages := "<empty>;.*jdbc.*;.*fs.*"
-coverageMinimum := 59 
+// Explanation for exclusions from unit test coverage:
+// - JDBC Layer: excluded as a bottom-layer component that does IO -- covered by integration tests.
+// - File Store Layer: excluded as a bottom-layer component that does IO -- covered by integration tests.
+// - Pipe Factory: as the rest of the components rely on abstract interfaces, this is the place
+//   that creates the concrete implementations of those, such as the bottom-layer components mentioned above.
+coverageExcludedPackages := "<empty>;.*jdbc.*;.*fs.*;.*core.factory.*"
+coverageMinimum := 59
 coverageFailOnMinimum := true
 
 assemblyShadeRules in assembly := Seq(

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
@@ -24,6 +24,7 @@ import scala.util.Failure
 import cats.data._
 import cats.data.Validated._
 import cats.implicits._
+import com.vertica.spark.datasource.core.factory.{VerticaPipeFactory, VerticaPipeFactoryInterface}
 import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
 
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSReader.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSReader.scala
@@ -15,6 +15,7 @@ package com.vertica.spark.datasource.core
 
 import com.vertica.spark.util.error._
 import com.vertica.spark.config._
+import com.vertica.spark.datasource.core.factory.{VerticaPipeFactory, VerticaPipeFactoryInterface}
 import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.InputPartition

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSReader.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSReader.scala
@@ -27,6 +27,11 @@ import org.apache.spark.sql.connector.read.InputPartition
 trait DSReaderInterface {
 
   /**
+   * Starts the read operation
+   */
+  def openRead(): ConnectorResult[Unit]
+
+  /**
    * Called by spark to read an individual row
    *
    * @return The next row if it exists, if the read is done None will be returned.

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSWriter.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSWriter.scala
@@ -14,6 +14,7 @@
 package com.vertica.spark.datasource.core
 
 import com.vertica.spark.config._
+import com.vertica.spark.datasource.core.factory.{VerticaPipeFactory, VerticaPipeFactoryInterface}
 import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
 import org.apache.spark.sql.catalyst.InternalRow
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -285,4 +285,5 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
     jdbcLayer.close()
     result
   }
+
 }

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -285,5 +285,4 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
     jdbcLayer.close()
     result
   }
-
 }

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.vertica.spark.datasource.core
+package com.vertica.spark.datasource.core.factory
 
 import com.vertica.spark.config._
+import com.vertica.spark.datasource.core._
 import com.vertica.spark.datasource.fs.HadoopFileStoreLayer
 import com.vertica.spark.datasource.jdbc.VerticaJdbcLayer
 import com.vertica.spark.util.cleanup.CleanupUtils

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Catalog.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Catalog.scala
@@ -35,7 +35,6 @@ final case class NoCatalogException(private val message: String = "Catalog funct
  */
 class VerticaDatasourceV2Catalog(readSetupInterface: DSConfigSetupInterface[ReadConfig] = new DSReadConfigSetup) extends TableCatalog{
 
-
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     VerticaDatasourceV2Catalog.catalogOptions = Some(options)
   }

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Catalog.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Catalog.scala
@@ -33,7 +33,8 @@ final case class NoCatalogException(private val message: String = "Catalog funct
  * and indicates whether the table already exists. This is in place to allow for the Ignore and ErrorIfExist
  * save modes.
  */
-class VerticaDatasourceV2Catalog(readSetupInterface: DSConfigSetupInterface[ReadConfig] = new DSReadConfigSetup) extends TableCatalog{
+class VerticaDatasourceV2Catalog() extends TableCatalog{
+  var readSetupInterface: DSConfigSetupInterface[ReadConfig] = new DSReadConfigSetup
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     VerticaDatasourceV2Catalog.catalogOptions = Some(options)

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.catalyst.InternalRow
 import com.vertica.spark.config.ReadConfig
-import com.vertica.spark.datasource.core.{DSConfigSetupInterface, DSReadConfigSetup, DSReader, DSReaderInterface, PushdownUtils}
+import com.vertica.spark.datasource.core.{DSConfigSetupInterface, DSReader, DSReaderInterface, PushdownUtils}
 import com.vertica.spark.util.error.{ConnectorError, ErrorHandling, InitialSetupPartitioningError}
 import org.apache.spark.sql.sources.Filter
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
@@ -145,8 +145,7 @@ class VerticaReaderFactory(config: ReadConfig) extends PartitionReaderFactory {
   */
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] =
   {
-    val reader = new DSReader(config, partition)
-    new VerticaBatchReader(config, reader)
+    new VerticaBatchReader(config, new DSReader(config, partition))
   }
 
 }
@@ -194,5 +193,10 @@ class VerticaBatchReader(config: ReadConfig, reader: DSReaderInterface) extends 
 /**
   * Calls underlying datasource to do any needed cleanup
   */
-  def close(): Unit = reader.closeRead()
+  def close(): Unit = {
+    reader.closeRead() match {
+      case Right(_) => ()
+      case Left(e) => ErrorHandling.logAndThrowError(logger, e)
+    }
+  }
 }

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Table.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Table.scala
@@ -17,8 +17,8 @@ import java.util
 
 import cats.data.Validated.{Invalid, Valid}
 import ch.qos.logback.classic.Level
-import com.vertica.spark.config.LogProvider
-import com.vertica.spark.datasource.core.{DSReadConfigSetup, DSWriteConfigSetup}
+import com.vertica.spark.config.{LogProvider, ReadConfig}
+import com.vertica.spark.datasource.core.{DSConfigSetupInterface, DSReadConfigSetup, DSWriteConfigSetup}
 import com.vertica.spark.datasource.v2
 import com.vertica.spark.util.error.{ErrorHandling, ErrorList}
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
@@ -34,7 +34,7 @@ import collection.JavaConverters._
  *
  * Supports Read and Write functionality.
  */
-class VerticaTable(caseInsensitiveStringMap: CaseInsensitiveStringMap) extends Table with SupportsRead with SupportsWrite {
+class VerticaTable(caseInsensitiveStringMap: CaseInsensitiveStringMap, readSetupInterface: DSConfigSetupInterface[ReadConfig] = new DSReadConfigSetup) extends Table with SupportsRead with SupportsWrite {
 
   // Cache the scan builder so we don't build it twice
   var scanBuilder : Option[VerticaScanBuilder] = None
@@ -54,7 +54,7 @@ class VerticaTable(caseInsensitiveStringMap: CaseInsensitiveStringMap) extends T
    */
   override def schema(): StructType = {
     // Check if there's a valid read config with schema for the table, if not return empty schema
-    (new DSReadConfigSetup).validateAndGetConfig(caseInsensitiveStringMap.asScala.toMap) match {
+    readSetupInterface.validateAndGetConfig(caseInsensitiveStringMap.asScala.toMap) match {
       case Invalid(_) => new StructType()
       case Valid(_) => this.newScanBuilder(caseInsensitiveStringMap).build().readSchema()
     }
@@ -68,7 +68,7 @@ class VerticaTable(caseInsensitiveStringMap: CaseInsensitiveStringMap) extends T
    */
   override def capabilities(): util.Set[TableCapability] =
     Set(TableCapability.BATCH_READ, TableCapability.BATCH_WRITE, TableCapability.OVERWRITE_BY_FILTER,
-      TableCapability.TRUNCATE, TableCapability.ACCEPT_ANY_SCHEMA).asJava  // Update this set with any capabilities this table supports
+      TableCapability.TRUNCATE, TableCapability.ACCEPT_ANY_SCHEMA).asJava
 
   /**
    * Returns a scan builder for reading from Vertica
@@ -80,7 +80,7 @@ class VerticaTable(caseInsensitiveStringMap: CaseInsensitiveStringMap) extends T
     this.scanBuilder match {
       case Some(builder) => builder
       case None =>
-        val config = (new DSReadConfigSetup).validateAndGetConfig(options.asScala.toMap) match {
+        val config = readSetupInterface.validateAndGetConfig(options.asScala.toMap) match {
           case Invalid(errList) =>
             val logger = LogProvider(Level.ERROR).getLogger(classOf[VerticaTable])
             ErrorHandling.logAndThrowError(logger, ErrorList(errList.toNonEmptyList))
@@ -88,7 +88,7 @@ class VerticaTable(caseInsensitiveStringMap: CaseInsensitiveStringMap) extends T
         }
         config.getLogger(classOf[VerticaTable]).debug("Config loaded")
 
-        val scanBuilder = new VerticaScanBuilder(config)
+        val scanBuilder = new VerticaScanBuilder(config, readSetupInterface)
         this.scanBuilder = Some(scanBuilder)
         scanBuilder
     }
@@ -101,15 +101,7 @@ class VerticaTable(caseInsensitiveStringMap: CaseInsensitiveStringMap) extends T
    */
   def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder =
   {
-    val config = new DSWriteConfigSetup(schema = Some(info.schema)).validateAndGetConfig(info.options.asScala.toMap) match {
-      case Invalid(errList) =>
-        val logger = LogProvider(Level.ERROR).getLogger(classOf[VerticaTable])
-        ErrorHandling.logAndThrowError(logger, ErrorList(errList.toNonEmptyList))
-      case Valid(cfg) => cfg
-    }
-    config.getLogger(classOf[VerticaTable]).debug("Config loaded")
-
-    new VerticaWriteBuilder(config)
+    new VerticaWriteBuilder(info, new DSWriteConfigSetup(schema = Some(info.schema)))
   }
 }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Write.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Write.scala
@@ -13,12 +13,16 @@
 
 package com.vertica.spark.datasource.v2
 
+import cats.data.Validated.{Invalid, Valid}
+import ch.qos.logback.classic.Level
 import com.typesafe.scalalogging.Logger
-import com.vertica.spark.config.WriteConfig
-import com.vertica.spark.datasource.core.{DSWriteConfigSetup, DSWriter}
-import com.vertica.spark.util.error.{ConnectorError, ErrorHandling}
+import com.vertica.spark.config.{LogProvider, WriteConfig}
+import com.vertica.spark.datasource.core.{DSConfigSetupInterface, DSWriteConfigSetup, DSWriter}
+import com.vertica.spark.util.error.{ConnectorError, ErrorHandling, ErrorList}
 import org.apache.spark.sql.connector.write._
 import org.apache.spark.sql.catalyst.InternalRow
+
+import collection.JavaConverters._
 
 object WriteSucceeded extends WriterCommitMessage
 object WriteFailed extends WriterCommitMessage
@@ -30,7 +34,16 @@ case class JobAbortedError() extends ConnectorError {
 /**
   * Builds the class for use in writing to Vertica
   */
-class VerticaWriteBuilder(config: WriteConfig) extends WriteBuilder with SupportsTruncate {
+class VerticaWriteBuilder(info: LogicalWriteInfo, writeSetupInterface: DSConfigSetupInterface[WriteConfig]) extends WriteBuilder with SupportsTruncate {
+
+  val config = writeSetupInterface.validateAndGetConfig(info.options.asScala.toMap) match {
+    case Invalid(errList) =>
+      val logger = LogProvider(Level.ERROR).getLogger(classOf[VerticaTable])
+      ErrorHandling.logAndThrowError(logger, ErrorList(errList.toNonEmptyList))
+    case Valid(cfg) => cfg
+  }
+  config.getLogger(classOf[VerticaTable]).debug("Config loaded")
+
 /**
   * Builds the class representing a write operation to a Vertica table
   *

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Write.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Write.scala
@@ -17,7 +17,7 @@ import cats.data.Validated.{Invalid, Valid}
 import ch.qos.logback.classic.Level
 import com.typesafe.scalalogging.Logger
 import com.vertica.spark.config.{LogProvider, WriteConfig}
-import com.vertica.spark.datasource.core.{DSConfigSetupInterface, DSWriteConfigSetup, DSWriter, DSWriterInterface}
+import com.vertica.spark.datasource.core.{DSConfigSetupInterface, DSWriter, DSWriterInterface}
 import com.vertica.spark.util.error.{ConnectorError, ErrorHandling, ErrorList}
 import org.apache.spark.sql.connector.write._
 import org.apache.spark.sql.catalyst.InternalRow
@@ -36,7 +36,7 @@ case class JobAbortedError() extends ConnectorError {
   */
 class VerticaWriteBuilder(info: LogicalWriteInfo, writeSetupInterface: DSConfigSetupInterface[WriteConfig]) extends WriteBuilder with SupportsTruncate {
 
-  val config = writeSetupInterface.validateAndGetConfig(info.options.asScala.toMap) match {
+  private val config = writeSetupInterface.validateAndGetConfig(info.options.asScala.toMap) match {
     case Invalid(errList) =>
       val logger = LogProvider(Level.ERROR).getLogger(classOf[VerticaTable])
       ErrorHandling.logAndThrowError(logger, ErrorList(errList.toNonEmptyList))

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Write.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Write.scala
@@ -17,7 +17,7 @@ import cats.data.Validated.{Invalid, Valid}
 import ch.qos.logback.classic.Level
 import com.typesafe.scalalogging.Logger
 import com.vertica.spark.config.{LogProvider, WriteConfig}
-import com.vertica.spark.datasource.core.{DSConfigSetupInterface, DSWriteConfigSetup, DSWriter}
+import com.vertica.spark.datasource.core.{DSConfigSetupInterface, DSWriteConfigSetup, DSWriter, DSWriterInterface}
 import com.vertica.spark.util.error.{ConnectorError, ErrorHandling, ErrorList}
 import org.apache.spark.sql.connector.write._
 import org.apache.spark.sql.catalyst.InternalRow
@@ -50,7 +50,7 @@ class VerticaWriteBuilder(info: LogicalWriteInfo, writeSetupInterface: DSConfigS
   * @return [[VerticaBatchWrite]]
   */
   override def buildForBatch(): BatchWrite = {
-    new VerticaBatchWrite(config)
+    new VerticaBatchWrite(config, writeSetupInterface)
   }
 
   def truncate: WriteBuilder = {
@@ -65,11 +65,11 @@ class VerticaWriteBuilder(info: LogicalWriteInfo, writeSetupInterface: DSConfigS
   *
   * Extends mixin class to represent type of write. Options are Batch or Stream, we are doing a batch write.
   */
-class VerticaBatchWrite(config: WriteConfig) extends BatchWrite {
+class VerticaBatchWrite(config: WriteConfig, writeSetupInterface: DSConfigSetupInterface[WriteConfig]) extends BatchWrite {
   private val logger: Logger = config.getLogger(classOf[VerticaBatchReader])
 
   // Perform initial setup for the write operation
-  new DSWriteConfigSetup(None).performInitialSetup(config) match {
+  writeSetupInterface.performInitialSetup(config) match {
     case Left(err) => ErrorHandling.logAndThrowError(logger, err)
     case Right(_) => ()
   }
@@ -121,19 +121,21 @@ class VerticaWriterFactory(config: WriteConfig) extends DataWriterFactory {
   * @param taskId A unique identifier for the specific task, which there may be multiple of for a partition due to retries or speculative execution
   * @return [[VerticaBatchWriter]]
   */
-  override def createWriter(partitionId: Int, taskId: Long): DataWriter[InternalRow] = new VerticaBatchWriter(config, partitionId, taskId)
+  override def createWriter(partitionId: Int, taskId: Long): DataWriter[InternalRow] = {
+    val uniqueId : String = partitionId + "-" + taskId
+    val writer = new DSWriter(config, uniqueId)
+    new VerticaBatchWriter(config, writer)
+  }
 }
 
 /**
   * Writer class that passes rows to be written to the underlying datasource
   */
-class VerticaBatchWriter(config: WriteConfig, partitionId: Int, taskId: Long) extends DataWriter[InternalRow] {
+class VerticaBatchWriter(config: WriteConfig, writer: DSWriterInterface) extends DataWriter[InternalRow] {
   private val logger: Logger = config.getLogger(classOf[VerticaBatchReader])
 
   // Construct a unique identifier string based on the partition and task IDs we've been passed for this operation
-  val uniqueId : String = partitionId + "-" + taskId
 
-  val writer = new DSWriter(config, uniqueId)
   writer.openWrite() match {
     case Right(_) => ()
     case Left(err) => ErrorHandling.logAndThrowError(logger, err)

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/DSConfigSetupTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/DSConfigSetupTest.scala
@@ -18,6 +18,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import com.vertica.spark.config._
 import ch.qos.logback.classic.Level
+import com.vertica.spark.datasource.core.factory.VerticaPipeFactoryInterface
 import org.scalamock.scalatest.MockFactory
 import com.vertica.spark.util.error._
 import com.vertica.spark.datasource.v2.DummyReadPipe

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/DSReaderTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/DSReaderTest.scala
@@ -17,6 +17,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import com.vertica.spark.config._
 import ch.qos.logback.classic.Level
+import com.vertica.spark.datasource.core.factory.VerticaPipeFactoryInterface
 import org.scalamock.scalatest.MockFactory
 import com.vertica.spark.util.error._
 import com.vertica.spark.datasource.v2.DummyReadPipe

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/DSWriterTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/DSWriterTest.scala
@@ -15,6 +15,7 @@ package com.vertica.spark.datasource.core
 
 import ch.qos.logback.classic.Level
 import com.vertica.spark.config.{DistributedFilesystemWriteConfig, FileStoreConfig, JDBCConfig, TableName}
+import com.vertica.spark.datasource.core.factory.VerticaPipeFactoryInterface
 import com.vertica.spark.util.error.MissingSchemaError
 import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
 import org.apache.spark.sql.catalyst.InternalRow

--- a/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
@@ -15,20 +15,29 @@ package com.vertica.spark.datasource.v2
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
-
 import com.vertica.spark.datasource._
-
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.connector.write._
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.catalog._
 import org.scalamock.scalatest.MockFactory
-
 import java.util
 
-import scala.collection.JavaConversions._
+import cats.data.Validated.{Invalid, Valid}
+import cats.implicits.catsSyntaxValidatedIdBinCompat0
+import ch.qos.logback.classic.Level
+import com.vertica.spark.config.{DistributedFilesystemReadConfig, DistributedFilesystemWriteConfig, FileStoreConfig, JDBCConfig, ReadConfig, TableName, ValidFilePermissions, WriteConfig}
 
+import scala.collection.JavaConversions._
 import com.vertica.spark.datasource.core._
+import com.vertica.spark.util.error.{CloseReadError, ConfigBuilderError, ConnectorException, ErrorList, FileListEmptyPartitioningError, IntermediaryStoreReaderNotInitializedError, SchemaDiscoveryError, UserMissingError}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.connector.write.LogicalWriteInfo
+import org.apache.spark.sql.sources.{Filter, GreaterThan, LessThan}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 
 trait DummyReadPipe extends VerticaPipeInterface with VerticaPipeReadInterface
 
@@ -40,11 +49,198 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
   override def afterAll(): Unit = {
   }
 
+  val jOptions = new util.HashMap[String, String]()
+  val options = new CaseInsensitiveStringMap(jOptions)
+
+  val tablename: TableName = TableName("testtable", None)
+  val jdbcConfig: JDBCConfig = JDBCConfig("1.1.1.1", 1234, "test", "test", "test", Level.ERROR)
+  val fileStoreConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/test", Level.ERROR)
+  val readConfig: DistributedFilesystemReadConfig = DistributedFilesystemReadConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig,  tablename = tablename, partitionCount = None, metadata = None, ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")))
+  val writeConfig: DistributedFilesystemWriteConfig = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig,  tablename = tablename, schema = new StructType(), targetTableSql = None, strlen = 1024, copyColumnList = None, sessionId = "id", failedRowPercentTolerance =  0.0f)
+
+  val intSchema = new StructType(Array(StructField("col1", IntegerType)))
+
+  val partition = VerticaDistributedFilesystemPartition(Seq(), None)
+
   it should "return a Vertica Table" in {
     val source = new VerticaSource()
-    val table = source.getTable(new StructType(), Array[Transform](), new util.HashMap[String, String]())
+    val table = source.getTable(new StructType(), Array[Transform](), jOptions)
 
     assert(table.isInstanceOf[VerticaTable])
   }
 
+  it should "table returns scan builder" in {
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+    (readSetup.validateAndGetConfig _).expects(options.toMap).returning(Valid(readConfig))
+
+    val table = new VerticaTable(options, readSetup)
+
+    table.newScanBuilder(options) match {
+      case _: VerticaScanBuilder => ()
+      case _ => fail("Wrong scan builder built")
+    }
+
+    // Call a second time, returns the same scan builder (only one call to the above mock required
+    table.newScanBuilder(options) match {
+      case _: VerticaScanBuilder => ()
+      case _ => fail("Wrong scan builder built")
+    }
+  }
+
+
+  it should "throws error getting scan builder" in {
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+    (readSetup.validateAndGetConfig _).expects(options.toMap).returning(UserMissingError().invalidNec)
+
+    val table = new VerticaTable(options, readSetup)
+
+    Try {
+      table.newScanBuilder(options)
+    } match {
+      case Success(_) => fail
+      case Failure(e) => e.asInstanceOf[ConnectorException].error.asInstanceOf[ErrorList].errors.head match {
+        case _: UserMissingError => ()
+        case _ => fail
+      }
+    }
+  }
+
+  it should "table returns capabilities" in {
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+
+    val table = new VerticaTable(options, readSetup)
+
+    table.capabilities() == Set(TableCapability.BATCH_READ, TableCapability.BATCH_WRITE, TableCapability.OVERWRITE_BY_FILTER,
+      TableCapability.TRUNCATE, TableCapability.ACCEPT_ANY_SCHEMA).asJava
+  }
+
+  it should "table returns schema" in {
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+    (readSetup.validateAndGetConfig _).expects(options.toMap).returning(Valid(readConfig)).twice()
+    (readSetup.getTableSchema _).expects(readConfig).returning(Right(intSchema))
+
+    val table = new VerticaTable(options, readSetup)
+
+    assert(table.schema() == intSchema)
+  }
+
+  it should "table returns empty table schema if no valid read of schema" in {
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+    (readSetup.validateAndGetConfig _).expects(options.toMap).returning(SchemaDiscoveryError(None).invalidNec)
+
+    val table = new VerticaTable(options, readSetup)
+
+    assert(table.schema() == new StructType())
+  }
+
+  it should "push filters on read" in {
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+
+    val scanBuilder = new VerticaScanBuilder(readConfig, readSetup)
+    val filters: Array[Filter] = Array(GreaterThan("col1", 5), LessThan("col2", 20))
+
+    val nonPushed = scanBuilder.pushFilters(filters)
+    assert(nonPushed.length == 0)
+
+    scanBuilder.pushedFilters().sameElements(filters)
+  }
+
+  it should "prune columns on read" in {
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+
+    val scanBuilder = new VerticaScanBuilder(readConfig, readSetup)
+
+    scanBuilder.pruneColumns(intSchema)
+
+    val scan = scanBuilder.build()
+
+    assert(scan.asInstanceOf[VerticaScan].getConfig.getRequiredSchema == intSchema)
+  }
+
+  it should "scan return input partitions" in {
+    val partitions: Array[InputPartition] = Array(partition)
+
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+    (readSetup.performInitialSetup _).expects(readConfig).returning(Right(Some(PartitionInfo(partitions))))
+
+    val scan = new VerticaScan(readConfig, readSetup)
+
+    assert(scan.planInputPartitions().sameElements(partitions))
+  }
+
+  it should "scan return error on partitions" in {
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+    (readSetup.performInitialSetup _).expects(readConfig).returning(Left(FileListEmptyPartitioningError()))
+
+    val scan = new VerticaScan(readConfig, readSetup)
+
+    Try {
+      scan.planInputPartitions()
+    } match {
+      case Success(_) => fail
+      case Failure(e) => e.asInstanceOf[ConnectorException].error match {
+        case _ : FileListEmptyPartitioningError => ()
+        case _ => fail(e)
+      }
+    }
+  }
+
+  it should "scan return reader factory" in {
+    val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
+
+    val scan = new VerticaScan(readConfig, readSetup)
+
+    assert(scan.createReaderFactory().isInstanceOf[VerticaReaderFactory])
+  }
+
+  it should "read from DSReader" in {
+    val dsReader = mock[DSReaderInterface]
+    (dsReader.openRead _).expects().returning(Right())
+    (dsReader.readRow _).expects().returning(Right(Some(InternalRow(5))))
+    (dsReader.readRow _).expects().returning(Right(Some(InternalRow(6))))
+    (dsReader.readRow _).expects().returning(Right(Some(InternalRow(2))))
+    (dsReader.readRow _).expects().returning(Right(Some(InternalRow(5))))
+    (dsReader.readRow _).expects().returning(Right(None))
+    (dsReader.closeRead _).expects().returning(Right())
+
+    val batchReader = new VerticaBatchReader(readConfig, dsReader)
+
+    var count = 0
+    while(batchReader.next) {
+      batchReader.get
+      count += 1
+    }
+
+    assert(count == 4)
+
+    batchReader.close()
+  }
+
+
+  it should "throw error in read" in {
+    val dsReader = mock[DSReaderInterface]
+    (dsReader.openRead _).expects().returning(Right())
+    (dsReader.readRow _).expects().returning(Left(IntermediaryStoreReaderNotInitializedError()))
+
+    val batchReader = new VerticaBatchReader(readConfig, dsReader)
+
+    Try {
+      batchReader.next
+      batchReader.get
+    } match {
+      case Success(_) => fail
+      case _ => ()
+    }
+  }
+
+  it should "build vertica batch write" in {
+    val info = mock[LogicalWriteInfo]
+    (info.options _).expects().returning(options)
+    val writeSetupInterface = mock[DSConfigSetupInterface[WriteConfig]]
+    (writeSetupInterface.validateAndGetConfig _).expects(options.toMap).returning(writeConfig.validNec)
+
+    val builder = new VerticaWriteBuilder(info, writeSetupInterface)
+
+    assert(builder.buildForBatch().isInstanceOf[VerticaBatchWrite])
+  }
 }

--- a/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
@@ -470,7 +470,8 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
     (readSetup.validateAndGetConfig _).expects(options.toMap).returning(Valid(readConfig)).twice()
     (readSetup.getTableSchema _).expects(readConfig).returning(Right(intSchema))
 
-    val catalog = new VerticaDatasourceV2Catalog(readSetup)
+    val catalog = new VerticaDatasourceV2Catalog()
+    catalog.readSetupInterface = readSetup
 
     catalog.initialize("VerticaTable", options)
 
@@ -481,7 +482,8 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
   it should "catalog loads table on load or create" in {
     val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
 
-    val catalog = new VerticaDatasourceV2Catalog(readSetup)
+    val catalog = new VerticaDatasourceV2Catalog()
+    catalog.readSetupInterface = readSetup
 
     catalog.initialize("VerticaTable", options)
 
@@ -491,7 +493,9 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
 
   it should "catalog does not support other operations" in {
     val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
-    val catalog = new VerticaDatasourceV2Catalog(readSetup)
+
+    val catalog = new VerticaDatasourceV2Catalog()
+    catalog.readSetupInterface = readSetup
 
     Try { catalog.alterTable(mock[Identifier], mock[TableChange]) }
     match {

--- a/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
@@ -22,14 +22,14 @@ import org.apache.spark.sql.connector.catalog._
 import org.scalamock.scalatest.MockFactory
 import java.util
 
-import cats.data.Validated.{Invalid, Valid}
+import cats.data.Validated.Valid
 import cats.implicits.catsSyntaxValidatedIdBinCompat0
 import ch.qos.logback.classic.Level
 import com.vertica.spark.config.{DistributedFilesystemReadConfig, DistributedFilesystemWriteConfig, FileStoreConfig, JDBCConfig, ReadConfig, TableName, ValidFilePermissions, WriteConfig}
 
 import scala.collection.JavaConversions._
 import com.vertica.spark.datasource.core._
-import com.vertica.spark.util.error.{CloseReadError, ConfigBuilderError, ConnectorException, ErrorList, FileListEmptyPartitioningError, InitialSetupPartitioningError, IntermediaryStoreReaderNotInitializedError, IntermediaryStoreWriterNotInitializedError, OpenWriteError, SchemaDiscoveryError, UserMissingError}
+import com.vertica.spark.util.error.{ConnectorException, ErrorList, FileListEmptyPartitioningError, InitialSetupPartitioningError, IntermediaryStoreReaderNotInitializedError, IntermediaryStoreWriterNotInitializedError, SchemaDiscoveryError, UserMissingError}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, PhysicalWriteInfo}
@@ -61,7 +61,7 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
 
   val intSchema = new StructType(Array(StructField("col1", IntegerType)))
 
-  val partition = VerticaDistributedFilesystemPartition(Seq(), None)
+  private val partition = VerticaDistributedFilesystemPartition(Seq(), None)
 
   it should "get no catalog options" in {
     VerticaDatasourceV2Catalog.getOptions match {

--- a/connector/src/test/scala/com/vertica/spark/util/cleanup/CleanupUtilsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/cleanup/CleanupUtilsTest.scala
@@ -26,7 +26,7 @@ class CleanupUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
 
   val cleanupUtils = new CleanupUtils(new LogProvider(Level.ERROR))
 
-  it should "Cleans up a file with a single part" in {
+  it should "Clean up a file with a single part" in {
     val filename = "path/file.parquet"
 
     val fileStoreLayer = mock[FileStoreLayerInterface]
@@ -132,7 +132,7 @@ class CleanupUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
     }
   }
 
-  it should "Cleans up all" in {
+  it should "Clean up all" in {
     val dirname = "path/path"
 
     val fileStoreLayer = mock[FileStoreLayerInterface]
@@ -144,7 +144,7 @@ class CleanupUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
     }
   }
 
-  it should "Returns error if java path returns null on cleanup all" in {
+  it should "Return error if java path returns null on cleanup all" in {
     val dirname = "/"
 
     val fileStoreLayer = mock[FileStoreLayerInterface]

--- a/connector/src/test/scala/com/vertica/spark/util/cleanup/CleanupUtilsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/cleanup/CleanupUtilsTest.scala
@@ -16,7 +16,7 @@ package com.vertica.spark.util.cleanup
 import ch.qos.logback.classic.Level
 import com.vertica.spark.config.LogProvider
 import com.vertica.spark.datasource.fs.FileStoreLayerInterface
-import com.vertica.spark.util.error.{CreateFileError, RemoveFileError}
+import com.vertica.spark.util.error.{CleanupError, CreateFileError, RemoveFileError}
 import org.apache.hadoop.fs.Path
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
@@ -129,6 +129,29 @@ class CleanupUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
         case RemoveFileError(_, _) => true
         case _ => false
       })
+    }
+  }
+
+  it should "Cleans up all" in {
+    val dirname = "path/path"
+
+    val fileStoreLayer = mock[FileStoreLayerInterface]
+    (fileStoreLayer.removeDir _).expects("path")
+
+    cleanupUtils.cleanupAll(fileStoreLayer, dirname) match {
+      case Left(e) => fail("Failure: " + e)
+      case Right(_) => ()
+    }
+  }
+
+  it should "Returns error if java path returns null on cleanup all" in {
+    val dirname = "/"
+
+    val fileStoreLayer = mock[FileStoreLayerInterface]
+
+    cleanupUtils.cleanupAll(fileStoreLayer, dirname) match {
+      case Right(_) => fail
+      case Left(e) => e.isInstanceOf[CleanupError]
     }
   }
 }

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -280,6 +280,63 @@ class SchemaToolsTests extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
     }
   }
 
+  it should "parse time type to string" in {
+    val (jdbcLayer, _, rsmd) = mockJdbcDeps(tablename)
+
+    mockColumnMetadata(rsmd, TestColumnDef(1, "col1", java.sql.Types.TIME, "TIME", 0, signed = true, nullable = true))
+    mockColumnCount(rsmd, 1)
+
+    new SchemaTools(logProvider).readSchema(jdbcLayer, tablename) match {
+      case Left(_) => fail
+      case Right(schema) =>
+        val fields = schema.fields
+        assert(fields.length == 1)
+        assert(fields(0).dataType == StringType)
+    }
+  }
+
+  it should "parse interval type to string" in {
+    val (jdbcLayer, _, rsmd) = mockJdbcDeps(tablename)
+
+    mockColumnMetadata(rsmd, TestColumnDef(1, "col1", java.sql.Types.OTHER, "interval", 0, signed = true, nullable = true))
+    mockColumnCount(rsmd, 1)
+
+    new SchemaTools(logProvider).readSchema(jdbcLayer, tablename) match {
+      case Left(_) => fail
+      case Right(schema) =>
+        val fields = schema.fields
+        assert(fields.length == 1)
+        assert(fields(0).dataType == StringType)
+    }
+  }
+
+  it should "parse uuid type to string" in {
+    val (jdbcLayer, _, rsmd) = mockJdbcDeps(tablename)
+
+    mockColumnMetadata(rsmd, TestColumnDef(1, "col1", java.sql.Types.OTHER, "uuid", 0, signed = true, nullable = true))
+    mockColumnCount(rsmd, 1)
+
+    new SchemaTools(logProvider).readSchema(jdbcLayer, tablename) match {
+      case Left(_) => fail
+      case Right(schema) =>
+        val fields = schema.fields
+        assert(fields.length == 1)
+        assert(fields(0).dataType == StringType)
+    }
+  }
+
+  it should "parse other type with error" in {
+    val (jdbcLayer, _, rsmd) = mockJdbcDeps(tablename)
+
+    mockColumnMetadata(rsmd, TestColumnDef(1, "col1", java.sql.Types.OTHER, "asdf", 0, signed = true, nullable = true))
+    mockColumnCount(rsmd, 1)
+
+    new SchemaTools(logProvider).readSchema(jdbcLayer, tablename) match {
+      case Left(e) => e.isInstanceOf[MissingSqlConversionError]
+      case Right(_) => fail
+    }
+  }
+
   it should "parse rowid to long type" in {
     val (jdbcLayer, _, rsmd) = mockJdbcDeps(tablename)
 


### PR DESCRIPTION
### Summary

Add Unit Tests to V2 API classes + some extra unit test coverage.

### Description

The V2 API classes were missing unit tests as they were deemed small and low impact enough, this adds unit tests for those classes, refactoring their interfaces slightly to allow for this. 

This PR also adds unit tests to a few other places in code to improve coverage.

### Related Issue

VER-75775

### Additional Reviewers

@jonathanl-bq 