### PR TITLE
Custom query option

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
@@ -78,7 +78,7 @@ object ValidFilePermissions {
  * @param logLevel Logging level for the read operation.
  * @param jdbcConfig Configuration for the JDBC connection used to communicate with Vertica.
  * @param fileStoreConfig Configuration for the intermediary filestore used to stage data between Spark and Vertica.
- * @param tablename Table to read from.
+ * @param tableSource Table or query to read from
  * @param partitionCount Number of Spark partitions to divide the read into.
  * @param metadata Contains any metadata from the Vertica table that needs to be retrieved before the read. Includes table schema.
  */
@@ -86,7 +86,7 @@ final case class DistributedFilesystemReadConfig(
                                                   override val logLevel: Level,
                                                   jdbcConfig: JDBCConfig,
                                                   fileStoreConfig: FileStoreConfig,
-                                                  tablename: TableName,
+                                                  tableSource: TableSource,
                                                   partitionCount: Option[Int],
                                                   metadata: Option[VerticaReadMetadata],
                                                   filePermissions: ValidFilePermissions

--- a/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
@@ -28,12 +28,14 @@ trait ReadConfig extends GenericConfig {
 
   /**
    * Set filters to push down to the Vertica read.
+   *
    * @param pushdownFilters Filter strings
    */
   def setPushdownFilters(pushdownFilters: List[PushdownFilter]): Unit
 
   /**
    * Sets the required schema of the read operation. Used to push down column selection
+   *
    * @param requiredSchema Schema of subset of data to be read from Vertica table
    */
   def setRequiredSchema(requiredSchema: StructType): Unit
@@ -78,7 +80,7 @@ object ValidFilePermissions {
  * @param logLevel Logging level for the read operation.
  * @param jdbcConfig Configuration for the JDBC connection used to communicate with Vertica.
  * @param fileStoreConfig Configuration for the intermediary filestore used to stage data between Spark and Vertica.
- * @param tableSource Table or query to read from
+ * @param tableSource Table or query to read from.
  * @param partitionCount Number of Spark partitions to divide the read into.
  * @param metadata Contains any metadata from the Vertica table that needs to be retrieved before the read. Includes table schema.
  */

--- a/connector/src/main/scala/com/vertica/spark/config/TableName.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/TableName.scala
@@ -63,10 +63,7 @@ final case class TableName(name: String, dbschema: Option[String]) extends Table
   override def identifier: String = name
 }
 
-
-final case class TableQuery(query: String) extends TableSource {
-  val id = SessionId.getId
-
-  override def identifier: String = id
+final case class TableQuery(query: String, uniqueId: String) extends TableSource {
+  override def identifier: String = uniqueId
 }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
@@ -114,18 +114,20 @@ object DSConfigSetupUtils {
     //TODO: make option once kerberos support is introduced
   }
 
-  def getTablename(config: Map[String, String]): ValidationResult[String] = {
-    config.get("table") match {
-      case Some(table) => table.validNec
-      case None => TablenameMissingError().invalidNec
+  def getTablename(config: Map[String, String]): Option[String] = {
+    config.get("table")
+  }
+
+  def getQuery(config: Map[String, String]): Option[String] = {
+    config.get("query") match {
+      case None => None
+        // Strip the ';' from the query to allow for queries ending with this
+      case Some(value) => Some(value.stripSuffix(";"))
     }
   }
 
-  def getDbSchema(config: Map[String, String]): ValidationResult[Option[String]] = {
-    config.get("dbschema") match {
-      case Some(dbschema) => Some(dbschema).validNec
-      case None => None.validNec
-    }
+  def getDbSchema(config: Map[String, String]): Option[String] = {
+    config.get("dbschema")
   }
 
   def getPassword(config: Map[String, String]): ValidationResult[String] = {
@@ -201,9 +203,28 @@ object DSConfigSetupUtils {
     )
   }
 
+  def validateAndGetTableSource(config: Map[String, String]): DSConfigSetupUtils.ValidationResult[TableSource] = {
+    val name = DSConfigSetupUtils.getTablename(config)
+    val schema = DSConfigSetupUtils.getDbSchema(config)
+    val query = DSConfigSetupUtils.getQuery(config)
+
+    (query, name) match {
+      case (Some(q), _) => TableQuery(q).validNec
+      case (None, Some(n)) => TableName(n, schema).validNec
+      case (None, None) => TableAndQueryMissingError().invalidNec
+    }
+  }
+
   def validateAndGetFullTableName(config: Map[String, String]): DSConfigSetupUtils.ValidationResult[TableName] = {
-    (DSConfigSetupUtils.getTablename(config),
-      DSConfigSetupUtils.getDbSchema(config) ).mapN(TableName)
+    val name = DSConfigSetupUtils.getTablename(config)
+    val schema = DSConfigSetupUtils.getDbSchema(config)
+    val query = DSConfigSetupUtils.getQuery(config)
+
+    (query, name) match {
+      case (_, Some(n)) => TableName(n, schema).validNec
+      case (Some(_), None) => QuerySpecifiedOnWriteError().invalidNec
+      case (None, None) => TablenameMissingError().invalidNec
+    }
   }
 
 }
@@ -222,11 +243,11 @@ class DSReadConfigSetup(val pipeFactory: VerticaPipeFactoryInterface = VerticaPi
 
     DSConfigSetupUtils.validateAndGetJDBCConfig(config).andThen { jdbcConfig =>
       DSConfigSetupUtils.validateAndGetFilestoreConfig(config, jdbcConfig.logLevel, sessionId).andThen { fileStoreConfig =>
-        DSConfigSetupUtils.validateAndGetFullTableName(config).andThen { tableName =>
+        DSConfigSetupUtils.validateAndGetTableSource(config).andThen { tableSource =>
             (jdbcConfig.logLevel.validNec,
             jdbcConfig.validNec,
             fileStoreConfig.validNec,
-            tableName.validNec,
+            tableSource.validNec,
             DSConfigSetupUtils.getPartitionCount(config),
             None.validNec,
             DSConfigSetupUtils.getFilePermissions(config)).mapN(DistributedFilesystemReadConfig).andThen { initialConfig =>

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
@@ -209,7 +209,7 @@ object DSConfigSetupUtils {
     val query = DSConfigSetupUtils.getQuery(config)
 
     (query, name) match {
-      case (Some(q), _) => TableQuery(q).validNec
+      case (Some(q), _) => TableQuery(q, SessionId.getId).validNec
       case (None, Some(n)) => TableName(n, schema).validNec
       case (None, None) => TableAndQueryMissingError().invalidNec
     }

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -223,7 +223,7 @@ class VerticaDistributedFilesystemReadPipe(
 
       exportSource = config.tableSource match {
         case tablename: TableName => tablename.getFullTableName
-        case query: TableQuery => "(" + query.query + ") AS x"
+        case TableQuery(query, _) => "(" + query + ") AS x"
       }
 
       exportStatement = "EXPORT TO PARQUET(" +

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -161,7 +161,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
       case None =>
         // Default COPY
         logger.info(s"Building default copy column list")
-        schemaTools.getCopyColumnList(jdbcLayer, config.tablename.getFullTableName, config.schema)
+        schemaTools.getCopyColumnList(jdbcLayer, config.tablename, config.schema)
           .left.map(err => SchemaColumnListError(err)
           .context("getColumnList: Error building default copy column list"))
     }

--- a/connector/src/main/scala/com/vertica/spark/util/error/ErrorHandling.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/error/ErrorHandling.scala
@@ -239,6 +239,12 @@ case class PasswordMissingError() extends ConnectorError {
 case class TablenameMissingError() extends ConnectorError {
   def getFullContext: String = "The 'table' param is missing. Please specify the name of the table to use."
 }
+case class TableAndQueryMissingError() extends ConnectorError {
+  def getFullContext: String = "The 'table' and 'query' params are both missing. Please specify the table name or query to use."
+}
+case class QuerySpecifiedOnWriteError() extends ConnectorError {
+  def getFullContext: String = "The 'query' option was specified for a write operation. This option is only valid for reads."
+}
 case class InvalidPortError() extends ConnectorError {
   def getFullContext: String = "The 'port' param specified is invalid. " +
     "Please specify a valid integer between 1 and 65535."

--- a/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
@@ -22,7 +22,7 @@ import cats.implicits._
 
 import scala.util.Either
 import cats.instances.list._
-import com.vertica.spark.config.LogProvider
+import com.vertica.spark.config.{LogProvider, TableName, TableQuery, TableSource}
 import com.vertica.spark.util.error.ErrorHandling.{ConnectorResult, SchemaResult}
 import com.vertica.spark.util.error._
 
@@ -46,19 +46,19 @@ trait SchemaToolsInterface {
    * Retrieves the schema of Vertica table in Spark format.
    *
    * @param jdbcLayer Depedency for communicating with Vertica over JDBC
-   * @param tablename Name of table we want the schema of.
+   * @param tableSource The table/query we want the schema of
    * @return StructType representing table's schema converted to Spark's schema type.
    */
-  def readSchema(jdbcLayer: JdbcLayerInterface, tablename: String): ConnectorResult[StructType]
+  def readSchema(jdbcLayer: JdbcLayerInterface, tableSource: TableSource): ConnectorResult[StructType]
 
   /**
    * Retrieves the schema of Vertica table in format of list of column definitions.
    *
    * @param jdbcLayer Depedency for communicating with Vertica over JDBC
-   * @param tablename Name of table we want the schema of.
+   * @param tableSource The table/query we want the schema of
    * @return Sequence of ColumnDef, representing the Vertica structure of schema.
    */
-  def getColumnInfo(jdbcLayer: JdbcLayerInterface, tablename: String): ConnectorResult[Seq[ColumnDef]]
+  def getColumnInfo(jdbcLayer: JdbcLayerInterface, tableSource: TableSource): ConnectorResult[Seq[ColumnDef]]
 
   /**
    * Returns the Vertica type to use for a given Spark type.
@@ -73,11 +73,11 @@ trait SchemaToolsInterface {
    * Compares table schema and spark schema to return a list of columns to use when copying spark data to the given Vertica table.
    *
    * @param jdbcLayer Depedency for communicating with Vertica over JDBC
-   * @param tablename Name of the table.
+   * @param tableName Name of the table we want to copy to
    * @param schema Schema of data in spark.
    * @return
    */
-  def getCopyColumnList(jdbcLayer: JdbcLayerInterface, tablename: String, schema: StructType): ConnectorResult[String]
+  def getCopyColumnList(jdbcLayer: JdbcLayerInterface, tableName: TableName, schema: StructType): ConnectorResult[String]
 
   /**
    * Matches a list of columns against a required schema, only returning the list of matches in string form.
@@ -146,8 +146,8 @@ class SchemaTools(val logProvider: LogProvider) extends SchemaToolsInterface {
     else Right(answer)
   }
 
-  def readSchema(jdbcLayer: JdbcLayerInterface, tablename: String): ConnectorResult[StructType] = {
-    this.getColumnInfo(jdbcLayer, tablename) match {
+  def readSchema(jdbcLayer: JdbcLayerInterface, tableSource: TableSource): ConnectorResult[StructType] = {
+    this.getColumnInfo(jdbcLayer, tableSource) match {
       case Left(err) => Left(err)
       case Right(colInfo) =>
         val errorsOrFields: List[Either[SchemaError, StructField]] = colInfo.map(info => {
@@ -162,11 +162,16 @@ class SchemaTools(val logProvider: LogProvider) extends SchemaToolsInterface {
     }
   }
 
-  def getColumnInfo(jdbcLayer: JdbcLayerInterface, tablename: String): ConnectorResult[Seq[ColumnDef]] = {
+  def getColumnInfo(jdbcLayer: JdbcLayerInterface, tableSource: TableSource): ConnectorResult[Seq[ColumnDef]] = {
     // Query for an empty result set from Vertica.
     // This is simply so we can load the metadata of the result set
     // and use this to retrieve the name and type information of each column
-    jdbcLayer.query("SELECT * FROM " + tablename + " WHERE 1=0") match {
+    val query = tableSource match {
+      case tablename: TableName => "SELECT * FROM " + tablename.getFullTableName + " WHERE 1=0"
+      case query: TableQuery => "SELECT * FROM (" + query.query + ") AS x WHERE 1=0"
+    }
+
+    jdbcLayer.query(query) match {
       case Left(err) => Left(JdbcSchemaError(err))
       case Right(rs) =>
         try {
@@ -226,9 +231,9 @@ class SchemaTools(val logProvider: LogProvider) extends SchemaToolsInterface {
   }
 
 
-  def getCopyColumnList(jdbcLayer: JdbcLayerInterface, tablename: String, schema: StructType): ConnectorResult[String] = {
+  def getCopyColumnList(jdbcLayer: JdbcLayerInterface, tableName: TableName, schema: StructType): ConnectorResult[String] = {
     for {
-      columns <- getColumnInfo(jdbcLayer, tablename)
+      columns <- getColumnInfo(jdbcLayer, tableName)
 
       columnList <- {
         val colCount = columns.length
@@ -246,7 +251,7 @@ class SchemaTools(val logProvider: LogProvider) extends SchemaToolsInterface {
                 // Log a warning if target column is not null and DF column is null
                 if (!column.nullable) {
                   if (s.nullable) {
-                    logger.warn("S2V: Column " + s.name + " is NOT NULL in target table " + tablename +
+                    logger.warn("S2V: Column " + s.name + " is NOT NULL in target table " + tableName.getFullTableName +
                       " but it's nullable in the DataFrame. Rows with NULL values in column " +
                       s.name + " will be rejected.")
                   }
@@ -260,7 +265,7 @@ class SchemaTools(val logProvider: LogProvider) extends SchemaToolsInterface {
         if (!(schema.length <= colCount)) {
           Left(TableNotEnoughRowsError().context("Error: Number of columns in the target table should be greater or equal to number of columns in the DataFrame. "
             + " Number of columns in DataFrame: " + schema.length + ". Number of columns in the target table: "
-            + tablename + ": " + colCount))
+            + tableName.getFullTableName + ": " + colCount))
         }
         // Load by Name:
         // if all cols in DataFrame were found in target table

--- a/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
@@ -55,7 +55,7 @@ trait SchemaToolsInterface {
    * Retrieves the schema of Vertica table in format of list of column definitions.
    *
    * @param jdbcLayer Depedency for communicating with Vertica over JDBC
-   * @param tableSource The table/query we want the schema of
+   * @param tableSource The table/query we want the schema of.
    * @return Sequence of ColumnDef, representing the Vertica structure of schema.
    */
   def getColumnInfo(jdbcLayer: JdbcLayerInterface, tableSource: TableSource): ConnectorResult[Seq[ColumnDef]]
@@ -73,7 +73,7 @@ trait SchemaToolsInterface {
    * Compares table schema and spark schema to return a list of columns to use when copying spark data to the given Vertica table.
    *
    * @param jdbcLayer Depedency for communicating with Vertica over JDBC
-   * @param tableName Name of the table we want to copy to
+   * @param tableName Name of the table we want to copy to.
    * @param schema Schema of data in spark.
    * @return
    */
@@ -168,7 +168,7 @@ class SchemaTools(val logProvider: LogProvider) extends SchemaToolsInterface {
     // and use this to retrieve the name and type information of each column
     val query = tableSource match {
       case tablename: TableName => "SELECT * FROM " + tablename.getFullTableName + " WHERE 1=0"
-      case query: TableQuery => "SELECT * FROM (" + query.query + ") AS x WHERE 1=0"
+      case TableQuery(query, _) => "SELECT * FROM (" + query + ") AS x WHERE 1=0"
     }
 
     jdbcLayer.query(query) match {

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/DSConfigSetupTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/DSConfigSetupTest.scala
@@ -101,7 +101,7 @@ class DSConfigSetupTest extends AnyFlatSpec with BeforeAndAfterAll with MockFact
         assert(config.jdbcConfig.db == "testdb")
         assert(config.jdbcConfig.username == "user")
         assert(config.jdbcConfig.password == "password")
-        assert(config.tablename.getFullTableName == "\"tbl\"")
+        assert(config.tableSource.asInstanceOf[TableName].getFullTableName == "\"tbl\"")
         assert(config.logLevel == Level.ERROR)
         config.metadata match {
           case Some(metadata) => assert(metadata.schema == new StructType())

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/DSConfigSetupUtilsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/DSConfigSetupUtilsTest.scala
@@ -18,7 +18,7 @@ import cats.data.{NonEmptyChain, ValidatedNec}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import ch.qos.logback.classic.Level
-import com.vertica.spark.config.{TableName, ValidColumnList, ValidFilePermissions}
+import com.vertica.spark.config.{TableName, TableQuery, TableSource, ValidColumnList, ValidFilePermissions}
 import org.scalamock.scalatest.MockFactory
 import com.vertica.spark.util.error._
 import org.scalactic.{Equality, TolerantNumerics}
@@ -161,19 +161,19 @@ class DSConfigSetupUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with Moc
 
   it should "parse the table name" in {
     val opts = Map("table" -> "tbl")
-    val table = getResultOrAssert[String](DSConfigSetupUtils.getTablename(opts))
-    assert(table == "tbl")
+    val table = DSConfigSetupUtils.getTablename(opts)
+    assert(table.get == "tbl")
   }
 
   it should "parse the db schema" in {
     val opts = Map("dbschema" -> "test")
-    val schema = getResultOrAssert[Option[String]](DSConfigSetupUtils.getDbSchema(opts))
+    val schema = DSConfigSetupUtils.getDbSchema(opts)
     assert(schema.get == "test")
   }
 
   it should "default to no schema" in {
     val opts = Map[String, String]()
-    val schema = getResultOrAssert[Option[String]](DSConfigSetupUtils.getDbSchema(opts))
+    val schema = DSConfigSetupUtils.getDbSchema(opts)
     schema match {
       case Some(_) => fail
       case None => ()
@@ -186,10 +186,32 @@ class DSConfigSetupUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with Moc
     assert(schema.getFullTableName == "\"test\".\"table\"")
   }
 
-  it should "fail with missing table name" in {
-    val opts = Map[String, String]()
-    val err = getErrorOrAssert[ConnectorError](DSConfigSetupUtils.getTablename(opts))
-    assert(err.toNonEmptyList.head == TablenameMissingError())
+  it should "get full table name of read" in {
+    val opts = Map("dbschema" -> "test", "table" -> "table")
+    val schema = getResultOrAssert[TableSource](DSConfigSetupUtils.validateAndGetTableSource(opts))
+    assert(schema.isInstanceOf[TableName])
+    assert(schema.asInstanceOf[TableName].getFullTableName == "\"test\".\"table\"")
+  }
+
+  it should "get table query" in {
+    val q = "select * from abc where n > 5"
+    val opts = Map("dbschema" -> "test", "query" -> q)
+    val schema = getResultOrAssert[TableSource](DSConfigSetupUtils.validateAndGetTableSource(opts))
+    assert(schema.isInstanceOf[TableQuery])
+    assert(schema.asInstanceOf[TableQuery].query == q)
+  }
+
+  it should "error if no table or query specified" in {
+    val opts = Map("dbschema" -> "test")
+    val err = getErrorOrAssert[ConnectorError](DSConfigSetupUtils.validateAndGetTableSource(opts))
+    assert(err.toNonEmptyList.head == TableAndQueryMissingError())
+  }
+
+  it should "error on query on write" in {
+    val q = "select * from abc where n > 5"
+    val opts = Map("dbschema" -> "test", "query" -> q)
+    val err = getErrorOrAssert[ConnectorError](DSConfigSetupUtils.validateAndGetFullTableName(opts))
+    assert(err.toNonEmptyList.head == QuerySpecifiedOnWriteError())
   }
 
   it should "parse the password" in {

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/DSReaderTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/DSReaderTest.scala
@@ -28,7 +28,7 @@ class DSReaderTest extends AnyFlatSpec with BeforeAndAfterAll with MockFactory {
   val tablename: TableName = TableName("testtable", None)
   val jdbcConfig: JDBCConfig = JDBCConfig("1.1.1.1", 1234, "test", "test", "test", Level.ERROR)
   val fileStoreConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/test", Level.ERROR)
-  val config: DistributedFilesystemReadConfig = DistributedFilesystemReadConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig,  tablename = tablename, partitionCount = None, metadata = None, ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")))
+  val config: DistributedFilesystemReadConfig = DistributedFilesystemReadConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig,  tableSource = tablename, partitionCount = None, metadata = None, ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")))
 
   override def beforeAll(): Unit = {
   }

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -168,7 +168,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
   }
 
   it should "export using query" in {
-    val query = TableQuery("SELECT * FROM t where n > 777")
+    val query = TableQuery("SELECT * FROM t where n > 777", "")
     val config = makeReadConfig.copy(tableSource = query)
 
     val fileStoreLayer = mockFileStoreLayer(config, fileStoreConfig.address + "/" + query.identifier)

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -284,7 +284,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename.getFullTableName, schema).returning(Right(""))
+    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -338,7 +338,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.close _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename.getFullTableName, schema).returning(Right(""))
+    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -372,7 +372,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename.getFullTableName, schema).returning(Right(""))
+    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(fileStoreConfig.address).returning(Right())
@@ -430,7 +430,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename.getFullTableName, schema).returning(Right("(\"col1\",\"col5\")"))
+    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right("(\"col1\",\"col5\")"))
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -456,7 +456,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename.getFullTableName, schema).returning(Right(""))
+    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -485,7 +485,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename.getFullTableName, schema).returning(Right(""))
+    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -514,7 +514,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.execute _).expects("DROP TABLE IF EXISTS \"dummy_id_COMMITS\" CASCADE", *).returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename.getFullTableName, schema).returning(Right(""))
+    (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())

--- a/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
@@ -56,7 +56,7 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
   val tablename: TableName = TableName("testtable", None)
   val jdbcConfig: JDBCConfig = JDBCConfig("1.1.1.1", 1234, "test", "test", "test", Level.ERROR)
   val fileStoreConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/test", Level.ERROR)
-  val readConfig: DistributedFilesystemReadConfig = DistributedFilesystemReadConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig,  tablename = tablename, partitionCount = None, metadata = None, ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")))
+  val readConfig: DistributedFilesystemReadConfig = DistributedFilesystemReadConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig,  tableSource = tablename, partitionCount = None, metadata = None, ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")))
   val writeConfig: DistributedFilesystemWriteConfig = DistributedFilesystemWriteConfig(logLevel = Level.ERROR, jdbcConfig = jdbcConfig, fileStoreConfig = fileStoreConfig,  tablename = tablename, schema = new StructType(), targetTableSql = None, strlen = 1024, copyColumnList = None, sessionId = "id", failedRowPercentTolerance =  0.0f)
 
   val intSchema = new StructType(Array(StructField("col1", IntegerType)))

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -20,7 +20,7 @@ import java.sql.ResultSet
 import java.sql.ResultSetMetaData
 
 import ch.qos.logback.classic.Level
-import com.vertica.spark.config.LogProvider
+import com.vertica.spark.config.{LogProvider, TableName, TableQuery}
 import com.vertica.spark.datasource.jdbc._
 import org.apache.spark.sql.types._
 import com.vertica.spark.util.error._
@@ -35,12 +35,25 @@ case class TestColumnDef(index: Int, name: String, colType: Int, colTypeName: St
 class SchemaToolsTests extends AnyFlatSpec with BeforeAndAfterAll with MockFactory with org.scalatest.OneInstancePerTest {
   private val logProvider = LogProvider(Level.ERROR)
 
-  private def mockJdbcDeps(tablename: String): (JdbcLayerInterface, ResultSet, ResultSetMetaData) = {
+  private def mockJdbcDeps(tablename: TableName): (JdbcLayerInterface, ResultSet, ResultSetMetaData) = {
     val jdbcLayer = mock[JdbcLayerInterface]
     val resultSet = mock[ResultSet]
     val rsmd = mock[ResultSetMetaData]
 
-    (jdbcLayer.query _).expects("SELECT * FROM " + tablename + " WHERE 1=0", *).returning(Right(resultSet))
+    (jdbcLayer.query _).expects("SELECT * FROM " + tablename.getFullTableName + " WHERE 1=0", *).returning(Right(resultSet))
+    (resultSet.getMetaData _).expects().returning(rsmd)
+    (resultSet.close _).expects()
+
+    (jdbcLayer, resultSet, rsmd)
+
+  }
+
+  private def mockJdbcDepsQuery(query: TableQuery): (JdbcLayerInterface, ResultSet, ResultSetMetaData) = {
+    val jdbcLayer = mock[JdbcLayerInterface]
+    val resultSet = mock[ResultSet]
+    val rsmd = mock[ResultSetMetaData]
+
+    (jdbcLayer.query _).expects("SELECT * FROM (" + query.query + ") AS x WHERE 1=0", *).returning(Right(resultSet))
     (resultSet.getMetaData _).expects().returning(rsmd)
     (resultSet.close _).expects()
 
@@ -61,7 +74,7 @@ class SchemaToolsTests extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
     (rsmd.getColumnCount _).expects().returning(count)
   }
 
-  val tablename = "\"testtable\""
+  val tablename = TableName("\"testtable\"", None)
 
   it should "parse a single-column double schema" in {
     val (jdbcLayer, _, rsmd) = mockJdbcDeps(tablename)
@@ -71,6 +84,24 @@ class SchemaToolsTests extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
     mockColumnCount(rsmd, 1)
 
     new SchemaTools(logProvider).readSchema(jdbcLayer, tablename) match {
+      case Left(err) => fail(err.toString())
+      case Right(schema) =>
+        val field = schema.fields(0)
+        assert(field.name == "col1")
+        assert(field.nullable)
+        assert(field.dataType == DoubleType)
+    }
+  }
+
+  it should "parse schema of query" in {
+    val query = TableQuery("SELECT * FROM t WHERE a > 1")
+    val (jdbcLayer, _, rsmd) = mockJdbcDepsQuery(query)
+
+    // Schema
+    mockColumnMetadata(rsmd, TestColumnDef(1, "col1", java.sql.Types.REAL, "REAL", 32, signed = false, nullable = true))
+    mockColumnCount(rsmd, 1)
+
+    new SchemaTools(logProvider).readSchema(jdbcLayer, query) match {
       case Left(err) => fail(err.toString())
       case Right(schema) =>
         val field = schema.fields(0)

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -94,7 +94,7 @@ class SchemaToolsTests extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
   }
 
   it should "parse schema of query" in {
-    val query = TableQuery("SELECT * FROM t WHERE a > 1")
+    val query = TableQuery("SELECT * FROM t WHERE a > 1", "")
     val (jdbcLayer, _, rsmd) = mockJdbcDepsQuery(query)
 
     // Schema

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -74,7 +74,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   }
 
   it should "read data from Vertica using join" in {
-
     val n = 1
 
     val tableName1 = "dftest1"

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -118,7 +118,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     TestUtils.dropTable(conn, tableName1)
   }
 
-  /*
   it should "read 20 rows of data from Vertica" in {
     val tableName1 = "dftest1"
     val stmt = conn.createStatement
@@ -3249,5 +3248,4 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     assert ( rowsLoaded == numDfRows )
     TestUtils.dropTable(conn, tableName)
   }
-   */
 }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -90,7 +90,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     TestUtils.populateTableBySQL(stmt, insert2, n)
 
     val query = "select * from " + tableName1 + " inner join " + tableName2 + " on " +
-      tableName1 + ".a == " + tableName2 + ".b"
+      tableName1 + ".a = " + tableName2 + ".b"
 
     val df: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(readOpts + ("query" -> query)).load()
 

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -74,7 +74,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   }
 
   it should "read data from Vertica using join" in {
-    val stmt = conn.createStatement
 
     val n = 1
 
@@ -82,8 +81,9 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     TestUtils.createTableBySQL(conn, tableName1, "create table " + tableName1 + " (a int)")
 
     val tableName2 = "dftest2"
-    TestUtils.createTableBySQL(conn, tableName1, "create table " + tableName2 + " (b int)")
+    TestUtils.createTableBySQL(conn, tableName2, "create table " + tableName2 + " (b int)")
 
+    val stmt = conn.createStatement
     val insert = "insert into "+ tableName1 + " values(2)"
     TestUtils.populateTableBySQL(stmt, insert, n)
     val insert2 = "insert into "+ tableName2 + " values(2)"

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -86,6 +86,8 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     val insert = "insert into "+ tableName1 + " values(2)"
     TestUtils.populateTableBySQL(stmt, insert, n)
+    val insert2 = "insert into "+ tableName2 + " values(2)"
+    TestUtils.populateTableBySQL(stmt, insert2, n)
 
     val query = "select * from " + tableName1 + " inner join " + tableName2 + " on " +
       tableName1 + ".a == " + tableName2 + ".b"


### PR DESCRIPTION
### Summary

Implement the option to specify a 'query' instead of a 'table'

### Description

- Add optional parent trait than can be either a table name or a query
- Parse one or the other on read
- On write, error if query is specified and table is not
- Test this using a join and aggregation

### Related Issue

VER-76082

### Additional Reviewers

@jonathanl-bq 
@NerdLogic 