### PR TITLE
Ver 76999: Fix integration tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,8 @@ jobs:
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
-      - name: Add hostfile entry for hdfs
-        run: echo "127.0.0.1 hdfs" | sudo tee -a /etc/hosts
+      - name: Build client image
+        run: docker build -t client ./docker
       - name: Run docker compose
         run: cd docker && docker-compose up -d
       - name: Replace HDFS core-site config with our own
@@ -57,7 +57,9 @@ jobs:
         with:
           name: build-jar-file
           path: ./functional-tests/lib/
+      - name: Copy functional tests to home directory of client container
+        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
       - name: Run the integration tests
-        run: cd functional-tests && sbt run
+        run: docker exec docker_client_1 cd /home/functional-tests && sbt run
       - name: Remove docker containers
         run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,6 @@ jobs:
       - name: Copy functional tests to home directory of client container
         run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
       - name: Run the integration tests
-        run: docker exec docker_client_1 cd /home/functional-tests && sbt run
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run
       - name: Remove docker containers
         run: cd docker && docker-compose down

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos:7
+
+ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,12 @@
 FROM centos:7
 
+ENV SBT_VERSION 1.3.13
+#ENV JAVA_OPTS="$JAVA_OPTS -Djava.security.auth.login.config=/spark-connector/conf/jaas.config"
+
+RUN yum install -y java-11-openjdk && \
+    yum install -y epel-release && \
+    yum update -y && yum install -y wget && \
+    wget http://dl.bintray.com/sbt/rpm/sbt-$SBT_VERSION.rpm && \
+    yum install -y sbt-$SBT_VERSION.rpm
+
 ENTRYPOINT ["/bin/bash"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,10 @@
 version: "3.9"
 services:
+  client:
+    image: client
+    volumes:
+      - "./..:/spark-connector"
+    stdin_open: true
   vertica:
     image: "glarik/vertica:10.0.0-RHEL7"
     ports:

--- a/functional-tests/src/main/resources/application.conf
+++ b/functional-tests/src/main/resources/application.conf
@@ -1,11 +1,11 @@
 functional-tests {
   host="vertica"
   port=5433
-  db="testdb"
-  user="release"
-  password="pass"
+  db="docker"
+  user="dbadmin"
+  password=""
   log=true
-  filepath="hdfs://eng-g9-200:8020/data/"
-  dirpath="hdfs://eng-g9-200:8020/data/dirtest/"
+  filepath="hdfs://hdfs:8020/data/"
+  dirpath="hdfs://hdfs:8020/data/dirtest/"
 }
 

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -27,7 +27,7 @@ object Main extends App {
     "staging_fs_url" -> conf.getString("functional-tests.filepath"),
     "logging_level" -> {if(conf.getBoolean("functional-tests.log")) "DEBUG" else "OFF"}
   )
-  val auth = if(conf.getString("functional-tests.password").nonEmpty) {
+  val auth = if(Try{conf.getString("functional-tests.password")}.isSuccess) {
     readOpts = readOpts + (
         "password" -> conf.getString("functional-tests.password"),
       )

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -17,6 +17,7 @@ import com.typesafe.config.Config
 import com.vertica.spark.config.{BasicJdbcAuth, DistributedFilesystemReadConfig, FileStoreConfig, JDBCConfig, JDBCSSLConfig, KerberosAuth, TableName, VerticaMetadata}
 import com.vertica.spark.functests.{CleanupUtilTests, EndToEndTests, HDFSTests, JDBCTests}
 import com.vertica.spark.functests.{CleanupUtilTests, EndToEndTests, HDFSTests, JDBCTests, LargeDataTests}
+import scala.util.Try
 
 object Main extends App {
   val conf: Config = ConfigFactory.load()

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -14,9 +14,8 @@
 import Main.conf
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.Config
-import com.vertica.spark.config.{BasicJdbcAuth, DistributedFilesystemReadConfig, FileStoreConfig, JDBCConfig, KerberosAuth, TableName, VerticaMetadata}
+import com.vertica.spark.config.{BasicJdbcAuth, DistributedFilesystemReadConfig, FileStoreConfig, JDBCConfig, JDBCSSLConfig, KerberosAuth, TableName, VerticaMetadata}
 import com.vertica.spark.functests.{CleanupUtilTests, EndToEndTests, HDFSTests, JDBCTests}
-import com.vertica.spark.config.{FileStoreConfig, JDBCConfig}
 import com.vertica.spark.functests.{CleanupUtilTests, EndToEndTests, HDFSTests, JDBCTests, LargeDataTests}
 
 object Main extends App {
@@ -51,10 +50,13 @@ object Main extends App {
     )
   }
 
+  val sslConfig = JDBCSSLConfig(ssl = false, None, None, None, None)
+
   val jdbcConfig = JDBCConfig(host = conf.getString("functional-tests.host"),
                               port = conf.getInt("functional-tests.port"),
                               db = conf.getString("functional-tests.db"),
-                              auth = auth)
+                              auth = auth,
+                              sslConfig = sslConfig)
 
   new JDBCTests(jdbcConfig).execute()
 

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -17,7 +17,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import com.vertica.spark.datasource.jdbc._
-import com.vertica.spark.config.{BasicJdbcAuth, JDBCConfig}
+import com.vertica.spark.config.{BasicJdbcAuth, JDBCConfig, JDBCSSLConfig}
 import com.vertica.spark.util.error.{ConnectionSqlError, DataTypeError, SyntaxError}
 
 /**
@@ -174,7 +174,8 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
   }
 
   it should "Fail to connect to the wrong database" in {
-    val badJdbcLayer = new VerticaJdbcLayer(JDBCConfig(host = jdbcCfg.host, port = jdbcCfg.port, db = jdbcCfg.db+"-doesnotexist123asdf", BasicJdbcAuth( username = "test", password = "test")))
+    val sslConfig = JDBCSSLConfig(ssl = false, None, None, None, None)
+    val badJdbcLayer = new VerticaJdbcLayer(JDBCConfig(host = jdbcCfg.host, port = jdbcCfg.port, db = jdbcCfg.db+"-doesnotexist123asdf", BasicJdbcAuth( username = "test", password = "test"), sslConfig))
 
     badJdbcLayer.execute("CREATE TABLE " + tablename + "(name integer);") match {
       case Right(u) => assert(false) // should not succeed


### PR DESCRIPTION
### Summary

This change fixes the IT tests in CI.

### Description

This change includes both a fix for the IT tests in CI, and also some improvements to the CI workflow. Instead of requiring a change to the hosts file, we now start up a sandbox client container and use that in the network with the other containers. Also, the logic for running the IT tests using Kerberos have been changed to allow using an empty password. Previously, it would try to use Kerberos authentication when the password was empty. Now it will only try Kerberos authentication if the password field is unspecified entirely.

### Related Issue

http://jira.verticacorp.com:8080/jira/browse/VER-76999

### Additional Reviewers

@alexr-bq 
@NerdLogic 
