### PR TITLE
Support kerberized hdfs without vertica

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -201,14 +201,7 @@ class VerticaDistributedFilesystemReadPipe(
       _ <- getMetadata
 
       // Set Vertica to work with kerberos and HDFS
-      _ <- config.jdbcConfig.auth match {
-        case _: KerberosAuth =>
-          logger.debug("Using kerberos auth.")
-          jdbcLayer.configureKerberosToFilestore(fileStoreLayer)
-        case _ =>
-          logger.debug("Using regular auth.")
-          Right(())
-      }
+      _ <- jdbcLayer.configureKerberosToFilestore(fileStoreLayer)
 
       // Create unique directory for session
       perm = config.filePermissions

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -261,11 +261,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
 
     val ret = for {
       // Set Vertica to work with kerberos and HDFS
-      _ <- config.jdbcConfig.auth match {
-        case _: KerberosAuth =>
-          jdbcLayer.configureKerberosToFilestore(fileStoreLayer)
-        case _ => Right(())
-      }
+      _ <- jdbcLayer.configureKerberosToFilestore(fileStoreLayer)
 
       // Get columnList
       columnList <- getColumnList.left.map(_.context("commit: Failed to get column list"))

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -288,7 +288,7 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
         val hadoopConf = session.sparkContext.hadoopConfiguration
         val isKerberosEnabled = hadoopConf.get("hadoop.security.authentication")
         logger.debug("Hadoop impersonation: kerb authentication: " + isKerberosEnabled)
-        if (isKerberosEnabled == "kerberos") {
+        if (isKerberosEnabled != null && isKerberosEnabled == "kerberos") {
           val nameNodeAddress = hadoopConf.get("dfs.namenode.http-address")
           logger.debug("Hadoop impersonation: name node address: " + nameNodeAddress)
 
@@ -303,7 +303,8 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
             _ <- this.execute(sql)
           } yield ()
         } else {
-          Left(KerberosNotEnabledInHadoopConf())
+          logger.info("Kerberos is not enabled in the hadoop config.")
+          Right(())
         }
       case None => Left(NoSparkSessionFound())
     }

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -286,9 +286,9 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
       case Some(session) =>
         logger.debug("Hadoop impersonation: found session")
         val hadoopConf = session.sparkContext.hadoopConfiguration
-        val isKerberosEnabled = hadoopConf.get("hadoop.security.authentication")
-        logger.debug("Hadoop impersonation: kerb authentication: " + isKerberosEnabled)
-        if (isKerberosEnabled != null && isKerberosEnabled == "kerberos") {
+        val authMethod = hadoopConf.get("hadoop.security.authentication")
+        logger.debug("Hadoop impersonation: auth method: " + authMethod)
+        if (authMethod != null && authMethod == "kerberos") {
           val nameNodeAddress = hadoopConf.get("dfs.namenode.http-address")
           logger.debug("Hadoop impersonation: name node address: " + nameNodeAddress)
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -62,6 +62,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
 
   private def mockJdbcLayer(expectedJdbcCommand: String, expectedJdbcParams: Seq[JdbcLayerParam] = Seq()): JdbcLayerInterface = {
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.execute _).expects(expectedJdbcCommand, expectedJdbcParams).returning(Right())
     (jdbcLayer.close _).expects().returning(Right(()))
     jdbcLayer
@@ -156,6 +157,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
 
     val jdbcLayer = mock[JdbcLayerInterface]
     val expectedJdbcCommand = "EXPORT TO PARQUET(directory = 'hdfs://example-hdfs:8020/tmp/test/dummy', fileSizeMB = 512, rowGroupSizeMB = 64, fileMode = '777', dirMode = '777') AS SELECT col1 FROM \"dummy\";"
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.execute _).expects(expectedJdbcCommand, *).returning(Right())
     (jdbcLayer.close _).expects().returning(Right(()))
 
@@ -193,6 +195,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     val fileStoreLayer = mockFileStoreLayer(config, fileStoreConfig.address + "/" + query.identifier)
 
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     val expectedJdbcCommand = "EXPORT TO PARQUET(directory = 'hdfs://example-hdfs:8020/tmp/test/" + query.identifier +
       "', fileSizeMB = 512, rowGroupSizeMB = 64, fileMode = '777', dirMode = '777') AS SELECT col1 " +
       "FROM (SELECT * FROM t where n > 777) AS x;"
@@ -216,6 +219,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (fileStoreLayer.fileExists _).expects(*).returning(Left(ParentDirMissingError("")))
 
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.close _).expects().returning(Right(()))
 
     val cleanupUtils = mock[CleanupUtilsInterface]
@@ -237,6 +241,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (fileStoreLayer.fileExists _).expects(*).returning(Right(false)).anyNumberOfTimes()
 
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.execute _).expects(*, *).returning(Left(ConnectionError(new Exception())))
     (jdbcLayer.close _).expects().returning(Right(()))
 
@@ -275,6 +280,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     }
 
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.execute _).expects(*, *).returning(Right())
     (jdbcLayer.close _).expects().returning(Right())
 
@@ -322,6 +328,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     }
 
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.execute _).expects(*, *).returning(Right())
     (jdbcLayer.close _).expects().returning(Right())
 
@@ -379,6 +386,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     }
 
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.execute _).expects(*, *).returning(Right())
     (jdbcLayer.close _).expects().returning(Right(()))
 
@@ -425,6 +433,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     }
 
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.execute _).expects(*, *).returning(Right())
     (jdbcLayer.close _).expects().returning(Right(()))
 
@@ -459,6 +468,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (fileStoreLayer.fileExists _).expects(*).returning(Right(false)).anyNumberOfTimes()
 
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.execute _).expects(*, *).returning(Right(()))
     (jdbcLayer.close _).expects().returning(Right(()))
 
@@ -491,6 +501,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (fileStoreLayer.getFileList _).expects(*).returning(Right(exportedFiles))
 
     val jdbcLayer = mock[JdbcLayerInterface]
+    (jdbcLayer.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayer.execute _).expects(*, *).returning(Right())
     (jdbcLayer.close _).expects().returning(Right(()))
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -282,6 +282,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val expected = "COPY \"dummy\"  FROM 'hdfs://example-hdfs:8020/tmp/test/*.parquet' ON ANY NODE parquet REJECTED DATA AS TABLE \"dummy_id_COMMITS\" NO COMMIT"
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*, *).returning(Right(1))
     (jdbcLayerInterface.query _).expects("EXPLAIN " + expected, *).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(expected, *).returning(Right(1))
@@ -310,6 +311,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val expected = "COPY \"dummy\" (col1 INTEGER, col2 FLOAT) FROM 'hdfs://example-hdfs:8020/tmp/test/*.parquet' ON ANY NODE parquet REJECTED DATA AS TABLE \"dummy_id_COMMITS\" NO COMMIT"
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*, *).returning(Right(1))
     (jdbcLayerInterface.query _).expects("EXPLAIN " + expected, *).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(expected, *).returning(Right(1))
@@ -334,6 +336,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = createWriteConfig()
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*, *).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*, *).returning(Left(SyntaxError(new Exception())))
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
@@ -362,6 +365,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = createWriteConfig()
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(1))
@@ -391,6 +395,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     )
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects("COPY \"dummy\" (col1,col3,col2) FROM 'hdfs://example-hdfs:8020/tmp/test/*.parquet' ON ANY NODE parquet REJECTED DATA AS TABLE \"dummy_id_COMMITS\" NO COMMIT", *).returning(Right(1))
@@ -416,6 +421,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val config = createWriteConfig()
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects("COPY \"dummy\" (\"col1\",\"col5\") FROM 'hdfs://example-hdfs:8020/tmp/test/*.parquet' ON ANY NODE parquet REJECTED DATA AS TABLE \"dummy_id_COMMITS\" NO COMMIT",*).returning(Right(1))
@@ -444,6 +450,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     )
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))
@@ -475,6 +482,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     )
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))
@@ -503,6 +511,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     )
 
     val jdbcLayerInterface = mock[JdbcLayerInterface]
+    (jdbcLayerInterface.configureKerberosToFilestore _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(1))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))


### PR DESCRIPTION
### Summary

Support kerberized hdfs without vertica.

### Description

Attempt to set kerberos config if hdfs configuration is set to work with kerberos. 

### Related Issue

VER-76995

### Additional Reviewers

@jonathanl-bq 