### PR TITLE
Ver 77001 & Ver 77061: Change default file permissions for HDFS

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
@@ -183,7 +183,7 @@ object DSConfigSetupUtils {
 
   def getFilePermissions(config: Map[String, String]): ValidationResult[ValidFilePermissions] = {
     config.get("file_permissions") match {
-      case None => ValidFilePermissions("770") // Default to allowing user and group
+      case None => ValidFilePermissions("600") // Default to allowing user and group
       case Some(str) => ValidFilePermissions(str)
     }
   }

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
@@ -183,7 +183,7 @@ object DSConfigSetupUtils {
 
   def getFilePermissions(config: Map[String, String]): ValidationResult[ValidFilePermissions] = {
     config.get("file_permissions") match {
-      case None => ValidFilePermissions("600") // Default to allowing user and group
+      case None => ValidFilePermissions("700") // Default to allowing user and group
       case Some(str) => ValidFilePermissions(str)
     }
   }


### PR DESCRIPTION
### Summary

This changes the default file and directory permissions for files stored in HDFS during Parquet EXPORTs.

### Description

This change sets the default file and directory permissions to 600. No tests are added as existing unit tests already check that the permissions are set in the EXPORT statement.

### Related Issue

http://jira.verticacorp.com:8080/jira/browse/VER-77001
http://jira.verticacorp.com:8080/jira/browse/VER-77061

### Additional Reviewers

@alexr-bq 
@NerdLogic 
