### PR TITLE
Fix hadoop umask and document permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ However you set up HDFS, Vertica needs to have a copy of the hadoop configuratio
 ALTER DATABASE <database name> SET HadoopConfDir = '/hadoop/conf/location/';
 ```
 
+
+
 ## Connector Usage
 
 Using the connector in Spark is straightforward. It requires the data source name, an options map, and if writing to Vertica, a [Spark Save Mode](https://spark.apache.org/docs/2.2.0/api/java/index.html?org/apache/spark/sql/SaveMode.html).
@@ -80,6 +82,20 @@ df.write.format("com.vertica.spark.datasource.VerticaSource").options(opts ).mod
 // Read it back from Vertica
 val dfRead: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(opts).load()
 ```
+
+### Note on permissions
+
+The connector, using an intermediary file location between Spark and Vertica, may require both sides to have write access to the intermediary location used. 
+
+The default permission (configurable via the 'file_permissions' option) is '700', or access only for the given user. This is the default for security reasons, but will cause issues if your user running spark and database user are different.
+
+There are a few ways to solve this:
+- Change the file_permissions option to a suitable value. Warning: setting this to '777' means any user with filesystem access could read the data being transfered. Setting this to '770' could work if users on each side of the operation share a group.
+- Change the operation to use the same user for spark and the database
+- Use export HADOOP_USER_NAME=<vertica-db-name> to have spark's hadoop communication use the same user as the DB
+
+
+### Connector Options
 
 Below is a detailed list of connector options:
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ However you set up HDFS, Vertica needs to have a copy of the hadoop configuratio
 ALTER DATABASE <database name> SET HadoopConfDir = '/hadoop/conf/location/';
 ```
 
-
-
 ## Connector Usage
 
 Using the connector in Spark is straightforward. It requires the data source name, an options map, and if writing to Vertica, a [Spark Save Mode](https://spark.apache.org/docs/2.2.0/api/java/index.html?org/apache/spark/sql/SaveMode.html).

--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -19,7 +19,7 @@ import java.util.Collections
 import com.vertica.spark.datasource.core.{DataBlock, ParquetFileRange}
 import com.vertica.spark.util.error.{CloseReadError, CloseWriteError, ConnectorError, CreateDirectoryAlreadyExistsError, CreateDirectoryError, CreateFileAlreadyExistsError, CreateFileError, DoneReading, FileListError, FileStoreThrownError, IntermediaryStoreReadError, IntermediaryStoreReaderNotInitializedError, IntermediaryStoreWriteError, IntermediaryStoreWriterNotInitializedError, MissingHDFSImpersonationTokenError, OpenReadError, OpenWriteError, RemoveDirectoryError, RemoveFileError}
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.{CommonConfigurationKeys, FileSystem, Path}
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetFileWriter, ParquetOutputFormat, ParquetWriter}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.parquet.ParquetWriteSupport
@@ -162,6 +162,7 @@ class HadoopFileStoreLayer(fileStoreConfig : FileStoreConfig, schema: Option[Str
   hdfsConfig.set(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE.key, "CORRECTED")
   hdfsConfig.set(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_READ.key, "CORRECTED")
   hdfsConfig.setEnum(ParquetOutputFormat.JOB_SUMMARY_LEVEL, JobSummaryLevel.NONE)
+  hdfsConfig.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "000")
 
   private class VerticaParquetBuilder(file: Path) extends ParquetWriter.Builder[InternalRow, VerticaParquetBuilder](file: Path) {
     override protected def self: VerticaParquetBuilder = this

--- a/examples/basic-read/src/main/scala/example/Main.scala
+++ b/examples/basic-read/src/main/scala/example/Main.scala
@@ -27,6 +27,7 @@ object Main extends App {
     "db" -> conf.getString("functional-tests.db"),
     "staging_fs_url" -> conf.getString("functional-tests.filepath"),
     "password" -> conf.getString("functional-tests.password"),
+    "file_permissions" -> "777",
     "logging_level" -> {if(conf.getBoolean("functional-tests.log")) "DEBUG" else "OFF"}
   )
 
@@ -45,14 +46,6 @@ object Main extends App {
 
     val insert = "insert into " + tableName + " values(2)"
     TestUtils.populateTableBySQL(stmt, insert, n)
-
-    val jdbcDf = spark.read.format("jdbc")
-      .option("url", "jdbc:vertica://" + readOpts("host") + ":5433" + "/" + readOpts("db") + "?user="+
-      readOpts("user")+"&password="+readOpts("password"))
-      .option("dbtable", tableName)
-      .option("driver", "com.vertica.jdbc.Driver")
-      .load()
-    jdbcDf.rdd.foreach(x => println("JDBC VALUE: " + x))
 
     val df: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(readOpts + ("table" -> tableName)).load()
 

--- a/examples/basic-read/src/main/scala/example/Main.scala
+++ b/examples/basic-read/src/main/scala/example/Main.scala
@@ -27,7 +27,6 @@ object Main extends App {
     "db" -> conf.getString("functional-tests.db"),
     "staging_fs_url" -> conf.getString("functional-tests.filepath"),
     "password" -> conf.getString("functional-tests.password"),
-    "file_permissions" -> "777",
     "logging_level" -> {if(conf.getBoolean("functional-tests.log")) "DEBUG" else "OFF"}
   )
 

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
@@ -20,6 +20,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import com.vertica.spark.datasource.core.{DataBlock, ParquetFileRange}
 import com.vertica.spark.datasource.fs.HadoopFileStoreLayer
 import com.vertica.spark.datasource.jdbc.{JdbcLayerInterface, VerticaJdbcLayer}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.permission.FsPermission
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.internal.SQLConf
@@ -29,7 +32,6 @@ import org.scalatest.BeforeAndAfterAll
 /**
  * Tests basic functionality of the VerticaHDFSLayer
  *
- * TODO: Update this with write functionality once we figure out how to add parquet footer to written files
  * Should ensure that reading from HDFS works correctly, as well as other operations, such as creating/removing files/directories and listing files.
  */
 
@@ -72,6 +74,18 @@ class HDFSTests(val fsCfg: FileStoreConfig, val dirTestCfg: FileStoreConfig, val
       case Right(_) => ()
       case Left(error) => fail(error.getFullContext)
     }
+  }
+
+  it should "Create dir with correct permissions" in {
+    val path = dirTestCfg.address
+    fsLayer.removeDir(path)
+    fsLayer.createDir(path, "777")
+
+    val p = new Path(path)
+    val fs = p.getFileSystem(new Configuration())
+
+    val perms = fs.getFileStatus(p).getPermission
+    assert(perms.equals(new FsPermission("777")))
   }
 
   it should "correctly read data from HDFS" in {
@@ -241,4 +255,6 @@ class HDFSTests(val fsCfg: FileStoreConfig, val dirTestCfg: FileStoreConfig, val
       }
     }
   }
+
+
 }


### PR DESCRIPTION
### Summary

Set hadoop configuration to not have a umask and document how to resolve permissions issues.

### Description

By default, hadoop uses a 0022 umask value, which messes with our connector where both sides need write permissions. This umask is a client-side value, so we disable it for our operation.

Additionally, documented the main ways to resolve permissions issues with the connector.

### Related Issue

VER-77200

### Additional Reviewers

@jonathanl-bq 
@NerdLogic 