### PR TITLE
Change examples to use jar from maven central and test

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,23 +7,12 @@ Clone this repository:
 ```
 git clone https://github.com/vertica/spark-connector.git
 ```
-
 From the project's root directory:
 ```
 cd docker
 docker compose up -d
 ```
 This will create a docker image for a client container and docker containers for a sandbox client environment and single-node clusters for both Vertica and HDFS.
-
-Next, change directory to the example you want to run. For example, if you want to run the "demo" example:
-```
-cd examples/demo
-```
-Now create a lib directory:
-```
-mkdir lib
-```
-Put the assembly jar for the connector in the lib folder you just created. If you don't have the jar file, you can download it here: https://github.com/vertica/spark-connector/releases
 
 Run the following commands to update the HDFS configuration files and restart HDFS:
 ```
@@ -35,4 +24,4 @@ docker exec docker_hdfs_1 /opt/hadoop/sbin/start-dfs.sh
 
 Run `docker exec -it docker_client_1 /bin/bash` to enter the sandbox client environment.
 
-Now just run `sbt run` from the `/spark-connector/examples/demo` directory.
+Now just run `sbt "run [CASE]"` from the `/spark-connector/examples/demo` directory.

--- a/examples/basic-read/build.sbt
+++ b/examples/basic-read/build.sbt
@@ -19,6 +19,9 @@ version := "1.0"
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
 
-libraryDependencies += "com.typesafe" % "config" % "1.4.1"
-libraryDependencies += "org.apache.spark" %% "spark-core" % "3.0.0"
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.0.0"
+libraryDependencies ++= Seq(
+  "com.typesafe" % "config" % "1.4.1",
+  "org.apache.spark" %% "spark-core" % "3.0.0",
+  "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "com.vertica.spark" % "vertica-spark" % "2.0.0-rc0"
+)

--- a/examples/basic-write/build.sbt
+++ b/examples/basic-write/build.sbt
@@ -19,6 +19,9 @@ version := "1.0"
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
 
-libraryDependencies += "com.typesafe" % "config" % "1.4.1"
-libraryDependencies += "org.apache.spark" %% "spark-core" % "3.0.0"
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.0.0"
+libraryDependencies ++= Seq(
+  "com.typesafe" % "config" % "1.4.1",
+  "org.apache.spark" %% "spark-core" % "3.0.0",
+  "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "com.vertica.spark" % "vertica-spark" % "2.0.0-rc0"
+)

--- a/examples/demo/build.sbt
+++ b/examples/demo/build.sbt
@@ -20,3 +20,4 @@ resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies += "com.typesafe" % "config" % "1.4.1"
+libraryDependencies += "com.vertica.spark" % "vertica-spark" % "2.0.0-rc0"

--- a/examples/demo/build.sbt
+++ b/examples/demo/build.sbt
@@ -19,5 +19,7 @@ version := "1.0"
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
 
-libraryDependencies += "com.typesafe" % "config" % "1.4.1"
-libraryDependencies += "com.vertica.spark" % "vertica-spark" % "2.0.0-rc0"
+libraryDependencies ++= Seq(
+  "com.typesafe" % "config" % "1.4.1",
+  "com.vertica.spark" % "vertica-spark" % "2.0.0-rc0"
+)

--- a/examples/kerberos-example/build.sbt
+++ b/examples/kerberos-example/build.sbt
@@ -19,8 +19,12 @@ version := "1.0"
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
 
-libraryDependencies += "com.typesafe" % "config" % "1.4.1"
-libraryDependencies += "org.apache.spark" %% "spark-core" % "3.0.0"
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.0.0"
+libraryDependencies ++= Seq(
+  "com.typesafe" % "config" % "1.4.1",
+  "org.apache.spark" %% "spark-core" % "3.0.0",
+  "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "com.vertica.spark" % "vertica-spark" % "2.0.0-rc0"
+)
+
 
 unmanagedClasspath in Runtime += new File("/etc/hadoop/conf/")


### PR DESCRIPTION
### Summary

Added library dependency for assembly JAR for connector from maven central.

### Description

When users were running the examples, they had to manually add a lib folder along with the JAR file. This step is now removed by adding the library dependency from maven central in the build.sbt file for each example. This change is also reflected in the READ.md file in the examples folder. 

### Related Issue

http://jira.verticacorp.com:8080/jira/browse/VER-77164

### Additional Reviewers

<!-- Any additional reviewers -->
@alexr-bq 
@jonathanl-bq 
@alexey-temnikov 