### PR TITLE
Fix cleanup method to work with S3.

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -341,7 +341,12 @@ class HadoopFileStoreLayer(fileStoreConfig : FileStoreConfig, schema: Option[Str
   override def createFile(filename: String): ConnectorResult[Unit] = {
     this.useFileSystem(filename, (fs, path) =>
       if (!fs.exists(path)) {
-        Try {fs.create(path); ()}.toEither.left.map(exception => CreateFileError(path, exception)
+        Try {
+          val stream = fs.create(path);
+          stream.write(0)
+          stream.close()
+          ()
+        }.toEither.left.map(exception => CreateFileError(path, exception)
           .context("Error creating HDFS file."))
       } else {
         Left(CreateFileAlreadyExistsError(filename))

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -570,8 +570,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val dfFiltered1 = df.filter("a < cast('2001-01-01' as date)")
     val dfFiltered2 = df.filter("a > cast('2001-01-01' as DATE)")
 
-    val r = dfFiltered1.count
-    val r2 = dfFiltered2.count
 
     assert(!dfFiltered1
       .queryExecution
@@ -584,6 +582,9 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
       .executedPlan
       .toString()
       .contains("Filter"))
+
+    val r = dfFiltered1.count
+    val r2 = dfFiltered2.count
 
     assert(r == n)
     assert(r2 == (n + 1))


### PR DESCRIPTION
### Summary

Before, the "create file" method used for cleanup just created an empty file. This was not working with S3. We now write a single 0 to this file.

### Related Issue

VER-77253

### Additional Reviewers

@jonathanl-bq 
@ravjotbrar