### PR TITLE
Update documentation with info on tuning Vertica export perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ where `{$SPARK_HOME}` is the `$SPARK_HOME` directory on the worker node.
 
 For information on how to configure Kerberos and TLS with the connector, see the [KerberosUserManual.md](https://github.com/vertica/spark-connector/blob/main/KerberosUserManual.md) and [TLSConfiguration.md](https://github.com/vertica/spark-connector/blob/main/TLSConfiguration.md) files in the root of this repository.
 
+For information on tuning performance, see [here in our performance-tests section.](performance-tests/README.md)
+
 ## Limitations
 
 The connector supports versions of Spark between 3.0 and 3.1.1.

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -24,7 +24,7 @@ The connector's Vertica-to-Spark functionality relies on a query to export data 
 
 It is suggested that the resource pool used for the operation is given as much memory as possible, and has its "plannedconcurrency" value set to as low as possible. 
 
-For an explanation of this, any given Vertica in query may only reserve its total provided memory divided by the plannedconcurrency value. A more detailed explanation can be found [here.](https://www.vertica.com/blog/do-you-need-to-put-your-query-on-a-budgetba-p236830/) The plannedconcurrency value sets how many independent queries are expected to be run, and the connector only uses one query at a time. This query is then parallelized by Vertica.
+For an explanation of this, any given Vertica query may only reserve its total provided memory divided by the plannedconcurrency value. A more detailed explanation can be found [here.](https://www.vertica.com/blog/do-you-need-to-put-your-query-on-a-budgetba-p236830/) The plannedconcurrency value sets how many independent queries are expected to be run, and the connector only uses one query at a time. This query is then parallelized by Vertica.
 
 ### Connector Options
 

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -31,7 +31,7 @@ For an explanation of this, any given Vertica query may only reserve its total p
 There are some connector parameters that may affect the performance of a read from Vertica operation.
 
 num_partitions: Will set how many partitions are created, representing how many parallel executors will be reading data from the intermediate location at once. This should roughly correspond to the processing power / number of cores in the spark cluster.
-max_file_size_export_mb and max_row_group_size_export_mb: Represent configuration of the parquet files exported from Vertica to the intermediary location. These values default to where we find the best export performance lies. However, these can be tweaked dependending on details of the given clusters.
+max_file_size_export_mb and max_row_group_size_export_mb: Represent configuration of the parquet files exported from Vertica to the intermediary location. These values default to where we find the best export performance lies: 16MB Row Group Size and 2048MB file size. However, these can be tweaked dependending on details of the given clusters. 
 
 ## Tuning write performance
 

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -16,12 +16,26 @@ Configuration is specified with application.conf (HOCON format)
 
 ## Tuning read performance
 
+The biggest factor in connector performance will be resources for Vertica and Spark. Vertica, particularly with default settings may run into a memory bottleneck. This can be improved via configuration of resource pools. 
+
+### Vertica Resource Pool Configuration
+
+The connector's Vertica-to-Spark functionality relies on a query to export data from Vertica to an intermediate filestore. This operation reserves a lot of memory, and the more memory available to it, the more threads it can create to parallelize the operation. 
+
+It is suggested that the resource pool used for the operation is given as much memory as possible, and has its "plannedconcurrency" value set to as low as possible. 
+
+For an explanation of this, any given Vertica in query may only reserve its total provided memory divided by the plannedconcurrency value. A more detailed explanation can be found [here.](https://www.vertica.com/blog/do-you-need-to-put-your-query-on-a-budgetba-p236830/) The plannedconcurrency value sets how many independent queries are expected to be run, and the connector only uses one query at a time. This query is then parallelized by Vertica.
+
+### Connector Options
+
 There are some connector parameters that may affect the performance of a read from Vertica operation.
 
 num_partitions: Will set how many partitions are created, representing how many parallel executors will be reading data from the intermediate location at once. This should roughly correspond to the processing power / number of cores in the spark cluster.
-max_file_size_export_mb and max_row_group_size_export_mb: Represent configuration of the files exported from Vertica to the intermediary location. These values default to where we find the best export performance lies. However, these can be tweaked dependending on details of the given clusters.
+max_file_size_export_mb and max_row_group_size_export_mb: Represent configuration of the parquet files exported from Vertica to the intermediary location. These values default to where we find the best export performance lies. However, these can be tweaked dependending on details of the given clusters.
 
 ## Tuning write performance
+
+Similar steps to the above for tuning Vertica resource pools may be helpful for write performance.
 
 On writing, the number of partitions is decided not by the connector, but by the number of partitions passed in. To change this, you can call the coalesce() function on a dataframe before writing it.
 


### PR DESCRIPTION
### Summary

Updated perf-tests documentation to include information on tuning Vertica for the operation. Added link to this from main readme.

### Additional Reviewers

@jonathanl-bq 
@ravjotbrar 
@NerdLogic 