### PR TITLE
Ensure clean-up is done in functional tests

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -284,6 +284,11 @@ class VerticaDistributedFilesystemReadPipe(
       totalRowGroups = fileMetadata.map(_.rowGroupCount).sum
 
       _ = logger.info("Total row groups: " + totalRowGroups)
+      // If table is empty, cleanup
+      _ =  if(totalRowGroups == 0) {
+        logger.info("Cleaning up all files in path: " + hdfsPath)
+        cleanupUtils.cleanupAll(fileStoreLayer, hdfsPath)
+      }
 
       partitionCount = if (totalRowGroups < requestedPartitionCount) {
         logger.info("Less than " + requestedPartitionCount + " partitions required, only using " + totalRowGroups)

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -286,7 +286,7 @@ class VerticaDistributedFilesystemReadPipe(
       _ = logger.info("Total row groups: " + totalRowGroups)
       // If table is empty, cleanup
       _ =  if(totalRowGroups == 0) {
-        logger.info("Cleaning up all files in path: " + hdfsPath)
+        logger.debug("Cleaning up empty directory in path: " + hdfsPath)
         cleanupUtils.cleanupAll(fileStoreLayer, hdfsPath)
       }
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -504,7 +504,6 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (fileStoreLayer.fileExists _).expects(*).returning(Right(false))
     (fileStoreLayer.fileExists _).expects(*).returning(Right(true))
 
-
     // Files returned by filesystem (mock of what vertica would create
     val exportedFiles = Array[String]()
     (fileStoreLayer.getFileList _).expects(*).returning(Right(exportedFiles))

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -504,6 +504,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (fileStoreLayer.fileExists _).expects(*).returning(Right(false))
     (fileStoreLayer.fileExists _).expects(*).returning(Right(true))
 
+
     // Files returned by filesystem (mock of what vertica would create
     val exportedFiles = Array[String]()
     (fileStoreLayer.getFileList _).expects(*).returning(Right(exportedFiles))
@@ -513,11 +514,12 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
     (jdbcLayer.execute _).expects(*, *).returning(Right())
     (jdbcLayer.close _).expects().returning(Right(()))
 
+    val cleanupUtils = mock[CleanupUtilsInterface]
+    (cleanupUtils.cleanupAll _).expects(*,*).returning(Right(()))
+
     val columnDef = ColumnDef("col1", java.sql.Types.REAL, "REAL", 32, 32, signed = false, nullable = true, metadata)
 
     val mockSchemaTools = this.mockSchemaTools(List(columnDef), "col1")
-
-    val cleanupUtils = mock[CleanupUtilsInterface]
 
     val pipe = new VerticaDistributedFilesystemReadPipe(config, fileStoreLayer, jdbcLayer, mockSchemaTools, cleanupUtils)
 

--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -19,7 +19,6 @@ version := "1.0"
 val sparkVersion = Option(System.getProperty("sparkVersion")).getOrElse("3.0.0")
 val hadoopVersion = Option(System.getProperty("hadoopVersion")).getOrElse("2.4.0")
 
-
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
 

--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -17,6 +17,7 @@ organization := "com.vertica"
 version := "1.0"
 
 val sparkVersion = Option(System.getProperty("sparkVersion")).getOrElse("3.0.0")
+val hadoopVersion= Option(System.getProperty("hadoopVersion")).getOrElse("2.4.0")
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
@@ -33,7 +34,7 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.2" % "test"
 libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.3.0"
-libraryDependencies += "org.apache.hadoop" % "hadoop-hdfs" % "2.4.0"
+libraryDependencies += "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion
 libraryDependencies += "org.apache.hadoop" % "hadoop-aws" % "3.3.0"
 
 

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -203,7 +203,7 @@ object Main extends App {
   ))
 
   val writeOpts = readOpts
-  runSuite(new EndToEndTests(readOpts, writeOpts, jdbcConfig))
+  runSuite(new EndToEndTests(readOpts, writeOpts, jdbcConfig, fileStoreConfig))
 
   if (args.length == 1 && args(0) == "Large") {
     runSuite(new LargeDataTests(readOpts, writeOpts, jdbcConfig))

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/CleanupUtilTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/CleanupUtilTests.scala
@@ -32,7 +32,7 @@ class CleanupUtilTests(val cfg: FileStoreConfig) extends AnyFlatSpec with Before
   }
 
   override def afterAll() = {
-    fsLayer.removeDir(path)
+    fsLayer.removeDir(cfg.address)
   }
 
   it should "Clean up a file" in {

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -47,6 +47,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     .getOrCreate()
 
   override def afterEach(): Unit ={
+    Thread.sleep(30000)
     val anyFiles= fsLayer.getFileList(fsConfig.address)
     assert(anyFiles.right.get.isEmpty)
   }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -15,23 +15,29 @@ package com.vertica.spark.functests
 
 import java.sql.{Connection, Date, Timestamp}
 
-import com.vertica.spark.config.JDBCConfig
+import com.vertica.spark.config.{FileStoreConfig, JDBCConfig}
 import com.vertica.spark.util.error.{CommitError, ConnectionSqlError, ConnectorException, ContextError, CreateTableError, DuplicateColumnsError, SchemaError, TempTableExistsError, ViewExistsError}
+import com.vertica.spark.datasource.fs.HadoopFileStoreLayer
 import org.apache.log4j.Logger
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DateType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType, TimestampType}
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode, SparkSession}
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalactic.TripleEquals._
 import org.scalactic.Tolerance._
 import org.apache.spark.sql.functions._
 
-class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String], jdbcConfig: JDBCConfig) extends AnyFlatSpec with BeforeAndAfterAll {
+
+class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String], jdbcConfig: JDBCConfig, fileStoreConfig: FileStoreConfig) extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfterEach {
+
   val conn: Connection = TestUtils.getJDBCConnection(jdbcConfig)
 
   val numSparkPartitions = 4
+  val fsConfig= FileStoreConfig(readOpts("staging_fs_url"), "", fileStoreConfig.awsOptions)
+  val fsLayer = new HadoopFileStoreLayer(fsConfig, None)
 
   private val spark = SparkSession.builder()
     .master("local[*]")
@@ -39,6 +45,11 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     .config("spark.executor.extraJavaOptions", "-Dcom.amazonaws.services.s3.enableV4=true")
     .config("spark.driver.extraJavaOptions", "-Dcom.amazonaws.services.s3.enableV4=true")
     .getOrCreate()
+
+  override def afterEach(): Unit ={
+    val anyFiles= fsLayer.getFileList(fsConfig.address)
+    assert(anyFiles.right.get.isEmpty)
+  }
 
   override def afterAll(): Unit = {
     spark.close()
@@ -675,35 +686,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     assert(r == n)
     assert(r2 == (n + 1))
 
-    stmt.execute("drop table " + tableName1)
-  }
-
-  it should "load data from Vertica with a TIMESTAMP-type pushdown filter" in {
-    val tableName1 = "dftest1"
-    val stmt = conn.createStatement()
-    val n = 3
-
-    TestUtils.createTableBySQL(conn, tableName1, "create table " + tableName1 + " (a TIMESTAMP, b float)")
-
-    var insert = "insert into "+ tableName1 + " values(TIMESTAMP '2010-03-25 12:47:32.62', 2.2)"
-    TestUtils.populateTableBySQL(stmt, insert, n)
-    insert = "insert into "+ tableName1 + " values(TIMESTAMP '2010-03-25 12:55:49.123456', 2.2)"
-    TestUtils.populateTableBySQL(stmt, insert, n + 1)
-
-    val df: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(readOpts + ("table" -> tableName1)).load()
-
-    val dr = df.filter("a = cast('2010-03-25 12:55:49.123456' AS TIMESTAMP)")
-    val r = dr.count
-
-    assert(!dr
-      .queryExecution
-      .executedPlan
-      .toString()
-      .contains("Filter"))
-
-    assert(r == n + 1)
-
-    dr.show
     stmt.execute("drop table " + tableName1)
   }
 
@@ -3286,5 +3268,40 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     }
     assert ( rowsLoaded == numDfRows )
     TestUtils.dropTable(conn, tableName)
+  }
+
+  it should "load data from Vertica with a TIMESTAMP-type pushdown filter" in {
+    val tableName1 = "dftest1"
+    val stmt = conn.createStatement()
+    val n = 3
+
+    TestUtils.createTableBySQL(conn, tableName1, "create table " + tableName1 + " (a TIMESTAMP, b float)")
+
+    var insert = "insert into "+ tableName1 + " values(TIMESTAMP '2010-03-25 12:47:32.62', 2.2)"
+    TestUtils.populateTableBySQL(stmt, insert, n)
+    insert = "insert into "+ tableName1 + " values(TIMESTAMP '2010-03-25 12:55:49.123456', 2.2)"
+    TestUtils.populateTableBySQL(stmt, insert, n + 1)
+
+    val df: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(readOpts + ("table" -> tableName1)).load()
+
+    val dr = df.filter("a = cast('2010-03-25 12:55:49.123456' AS TIMESTAMP)")
+    val r = dr.count
+
+    assert(!dr
+      .queryExecution
+      .executedPlan
+      .toString()
+      .contains("Filter"))
+
+    assert(r == n + 1)
+
+    dr.show
+    stmt.execute("drop table " + tableName1)
+    if(!fsLayer.getFileList(fsConfig.address).right.get.isEmpty) {
+      fsLayer.removeDir(fsConfig.address)
+      // Need to recreate the root directory for the afterEach assertion check
+      fsLayer.createDir(fsConfig.address, "777")
+    }
+
   }
 }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -30,7 +30,6 @@ import org.scalactic.TripleEquals._
 import org.scalactic.Tolerance._
 import org.apache.spark.sql.functions._
 
-
 class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String], jdbcConfig: JDBCConfig, fileStoreConfig: FileStoreConfig) extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfterEach {
 
   val conn: Connection = TestUtils.getJDBCConnection(jdbcConfig)
@@ -3322,5 +3321,4 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     assert ( rowsLoaded == numDfRows )
     TestUtils.dropTable(conn, tableName)
   }
-
 }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -1671,7 +1671,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "halt if table name already exists as view." in {
     val stmt = conn.createStatement()
 
-    val path = "/test/"
     val tableName = "s2vdevtest17"
     val viewName = tableName + "view"
 
@@ -1700,8 +1699,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     df.show
     println("numDfRows=" + numDfRows)
 
-    val options = writeOpts + ("table" -> viewName, "dbschema" -> dbschema,
-    "staging_fs_url" -> (writeOpts("staging_fs_url").stripSuffix("/") + path))
+    val options = writeOpts + ("table" -> viewName, "dbschema" -> dbschema)
 
     val mode = SaveMode.Overwrite
     var failure: Option[Exception] = None
@@ -1719,7 +1717,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "ErrorIfExists mode should save to Vertica if table does not already exist in Vertica." in {
     var stmt = conn.createStatement()
 
-    val path = "/test/"
     val tableName = "s2vdevtest18"
     val dbschema = "public"
 
@@ -1743,8 +1740,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     df.show
     println("numDfRows=" + numDfRows)
 
-    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema,
-      "staging_fs_url" -> (writeOpts("staging_fs_url").stripSuffix("/") + path))
+    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema)
 
     val mode = SaveMode.ErrorIfExists
     df.write.format("com.vertica.spark.datasource.VerticaSource").options(options).mode(mode).save()
@@ -1769,7 +1765,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     val stmt = conn.createStatement()
 
-    val path = "/test/"
     val tableName = "s2vdevtest19"
     val dbschema = "public"
 
@@ -1794,8 +1789,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     df.show
     println("numDfRows=" + numDfRows)
 
-    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema,
-      "staging_fs_url" -> (writeOpts("staging_fs_url").stripSuffix("/") + path))
+    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema)
 
     val mode = SaveMode.ErrorIfExists
     var failure: Option[Exception] = None
@@ -1812,9 +1806,9 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "Ignore mode should save to Vertica if table does not already exist in Vertica." in {
     var stmt = conn.createStatement()
 
-    val path = "/test/"
     val tableName = "s2vdevtest20"
     val dbschema = "public"
+    val path="/test/"
 
     stmt.execute("DROP TABLE  IF EXISTS "+ tableName)
 
@@ -1856,12 +1850,14 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     }
     assert (rowsLoaded == numDfRows)
     TestUtils.dropTable(conn, tableName)
+    fsLayer.removeDir(fsConfig.address)
+    // Need to recreate the root directory for the afterEach assertion check
+    fsLayer.createDir(fsConfig.address, "777")
   }
 
   it should "Ignore mode should NOT save to Vertica and ignores the load if table already exists in Vertica." in {
     val stmt = conn.createStatement()
 
-    val path = "/test/"
     val tableName = "s2vdevtest21"
     val dbschema = "public"
 
@@ -1886,8 +1882,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     df.show
     println("numDfRows=" + numDfRows)
 
-    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema,
-      "staging_fs_url" -> (writeOpts("staging_fs_url").stripSuffix("/") + path))
+    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema)
 
     val mode = SaveMode.Ignore
     var failure: Option[Exception] = None
@@ -2014,7 +2009,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "Should throw clear error message if data frame contains a complex data type not supported by Vertica." in {
     val stmt = conn.createStatement()
 
-    val path = "/test/"
     val tableName = "s2vdevtest24"
     val dbschema = "public"
 
@@ -2035,8 +2029,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     println("numDfRows=" + numDfRows)
 
 
-    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema,
-      "staging_fs_url" -> (writeOpts("staging_fs_url").stripSuffix("/") + path))
+    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema)
 
     val mode = SaveMode.Overwrite
     var failure: Option[Exception] = None
@@ -2054,7 +2047,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "Should not try to save an empty dataframe." in {
     val stmt = conn.createStatement()
 
-    val path = "/test/"
     val tableName = "s2vdevtest25"
     val dbschema = "public"
 
@@ -2068,8 +2060,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     val numDfRows = df.count
     println("numDfRows=" + numDfRows)
 
-    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema,
-      "staging_fs_url" -> (writeOpts("staging_fs_url").stripSuffix("/") + path))
+    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema)
 
     val mode = SaveMode.Overwrite
     var failure: Option[Exception] = None
@@ -2087,7 +2078,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "Should drop rejects table if it is empty." in {
     val stmt = conn.createStatement()
 
-    val path = "/test/"
     val rand = scala.util.Random.nextInt(10000000)
     val tableName = "s2vdevtest26" + "_" + rand.toString
     val dbschema = "public"
@@ -2113,8 +2103,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     println("numDfRows=" + numDfRows)
 
 
-    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema,
-      "staging_fs_url" -> (writeOpts("staging_fs_url").stripSuffix("/") + path))
+    val options = writeOpts + ("table" -> tableName, "dbschema" -> dbschema)
 
     val mode = SaveMode.Overwrite
     df.write.format("com.vertica.spark.datasource.VerticaSource").options(options).mode(mode).save()

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -1671,7 +1671,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "halt if table name already exists as view." in {
     val stmt = conn.createStatement()
 
-    val path = "/data/test/"
+    val path = "/test/"
     val tableName = "s2vdevtest17"
     val viewName = tableName + "view"
 
@@ -1719,7 +1719,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "ErrorIfExists mode should save to Vertica if table does not already exist in Vertica." in {
     var stmt = conn.createStatement()
 
-    val path = "/data/test/"
+    val path = "/test/"
     val tableName = "s2vdevtest18"
     val dbschema = "public"
 
@@ -1769,7 +1769,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     val stmt = conn.createStatement()
 
-    val path = "/data/test/"
+    val path = "/test/"
     val tableName = "s2vdevtest19"
     val dbschema = "public"
 
@@ -1812,7 +1812,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "Ignore mode should save to Vertica if table does not already exist in Vertica." in {
     var stmt = conn.createStatement()
 
-    val path = "/data/test/"
+    val path = "/test/"
     val tableName = "s2vdevtest20"
     val dbschema = "public"
 
@@ -1861,7 +1861,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "Ignore mode should NOT save to Vertica and ignores the load if table already exists in Vertica." in {
     val stmt = conn.createStatement()
 
-    val path = "/data/test/"
+    val path = "/test/"
     val tableName = "s2vdevtest21"
     val dbschema = "public"
 
@@ -2014,7 +2014,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "Should throw clear error message if data frame contains a complex data type not supported by Vertica." in {
     val stmt = conn.createStatement()
 
-    val path = "/data/test/"
+    val path = "/test/"
     val tableName = "s2vdevtest24"
     val dbschema = "public"
 
@@ -2054,7 +2054,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "Should not try to save an empty dataframe." in {
     val stmt = conn.createStatement()
 
-    val path = "/data/test/"
+    val path = "/test/"
     val tableName = "s2vdevtest25"
     val dbschema = "public"
 
@@ -2087,7 +2087,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "Should drop rejects table if it is empty." in {
     val stmt = conn.createStatement()
 
-    val path = "/data/test/"
+    val path = "/test/"
     val rand = scala.util.Random.nextInt(10000000)
     val tableName = "s2vdevtest26" + "_" + rand.toString
     val dbschema = "public"

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
@@ -58,6 +58,8 @@ class HDFSTests(val fsCfg: FileStoreConfig, val jdbcCfg: JDBCConfig) extends Any
   }
 
   override def afterAll(): Unit = {
+    val rootDir= fsCfg.address.stripSuffix("filestoretest")
+    fsLayer.removeDir(rootDir)
     spark.close()
   }
 


### PR DESCRIPTION
### Summary

This update ensures cleanup is done in all functional tests, including after calls that only invoked the initial setup of a read. 

### Description

In the HDFS tests, we now clean up the root directory of the bucket, instead of only the dirtest directory by calling removeDir on the filestore config address. Similarly, in the cleanuputils tests, we clean up the root directory instead of only /CleanupTest. Finally, in the EndtoEnd tests, we assert that all files are cleaned up after each test. We manually clean up files in cases that call our initial read setup, but don't actually read the data. In addition, cleanup is now triggered on reads involving empty tables, and the path that is appended to the test bucket in write tests is removed. 

### Related Issue

http://jira.verticacorp.com:8080/jira/browse/VER-77503

### Additional Reviewers

@jonathanl-bq 
@alexr-bq 
