### PR TITLE
Change trigger condition to run when PR is merged

### DIFF
--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -1,9 +1,8 @@
 name: S3-Integration
 
 on:
-  schedule:
-    # Every day at 2am
-    - cron: '0 2 * * *'
+  push:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
### Summary

This change updates when the S3-Integration workflow is triggered.

### Description

Initially, we had set the S3-integration workflow to run daily at a specified time. This update changes the workflow to run when a PR is merged by specifying the trigger as a push on the main branch.

### Related Issue

http://jira.verticacorp.com:8080/jira/browse/VER-76345

### Additional Reviewers

@jonathanl-bq @alexr-bq 
