### PR TITLE
Fix scripts for Pyspark and s3 examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -52,7 +52,7 @@ Once you're finished running the examples exit out of the interactive terminal b
 
 ## Running Example Application in Spark Cluster
 
-Note: this method is required for the S3-example. 
+Note: this method is required for the S3-example and PySpark example. 
 
 In the example's root directory (spark-connector/examples/[EXAMPLE]) , run `sbt assembly`:
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # How to run the examples
 
-**Note**: The instructions for running the S3, Kerberos, and PySpark example are different. If you would like to run that example, please see their respective READMEs. 
+**Note**: The instructions for running the S3, Kerberos, and PySpark example are different. If you would like to run those examples, please see their respective READMEs. 
 
 Make sure you have docker and sbt installed.
 Tested using docker 20.10.0, sbt 1.4.1
@@ -52,7 +52,7 @@ Once you're finished running the examples exit out of the interactive terminal b
 
 ## Running Example Application in Spark Cluster
 
-Note: this method is required for the S3-example and PySpark example. 
+Note: this method is required for the S3-example. 
 
 In the example's root directory (spark-connector/examples/[EXAMPLE]) , run `sbt assembly`:
 ```

--- a/examples/pyspark/README.md
+++ b/examples/pyspark/README.md
@@ -2,4 +2,4 @@
 
 The connector can be used with pyspark, it must simply be sourced as a JAR file. 
 
-An example application is provided alongside a .sh file which shows how to run such an application with the connector. It can be run using "./run-example.sh". This script will download Python3, Spark, and Hadoop and configure them before running the example.
+An example application is provided alongside a .sh file which shows how to run such an application with the connector. It can be run using "./run-python-example.sh". This script will download Python3, Spark, and Hadoop and configure them before running the example.

--- a/examples/pyspark/README.md
+++ b/examples/pyspark/README.md
@@ -2,4 +2,4 @@
 
 The connector can be used with pyspark, it must simply be sourced as a JAR file. 
 
-An example application is provided alongside a .sh file which shows how to run such an application with the connector.
+An example application is provided alongside a .sh file which shows how to run such an application with the connector. It can be run using "./run-example.sh". This script will download Python3, Spark, and Hadoop and configure them before running the example.

--- a/examples/pyspark/run-python-example.sh
+++ b/examples/pyspark/run-python-example.sh
@@ -1,1 +1,48 @@
-spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-1.0.jar sparkapp.py 
+if [ "$1" == "clean" ]
+  then
+    yum install -y python3
+    wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.2/spark-3.0.2-bin-without-hadoop.tgz
+    wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
+    cd ../../
+    tar xvf spark-3.0.2-bin-without-hadoop.tgz
+    tar xvf hadoop-3.3.0.tar.gz
+    mv spark-3.0.2-bin-without-hadoop/ /opt/spark
+    cd /opt/spark/conf
+    mv spark-env.sh.template spark-env.sh
+    export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
+    export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
+    export SPARK_HOME=/opt/spark
+    export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
+    start-master.sh
+    start-slave.sh spark://localhost:7077
+    cd ../../../spark-connector/examples
+    spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-1.0.jar sparkapp.py
+
+elif [ -a ../../hadoop-3.3.0 ]
+  then
+    export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
+    export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
+    export SPARK_HOME=/opt/spark
+    export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
+    spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-1.0.jar sparkapp.py
+
+else
+  yum install -y python3
+  wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.2/spark-3.0.2-bin-without-hadoop.tgz
+  wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
+  cd ../../
+  tar xvf spark-3.0.2-bin-without-hadoop.tgz
+  tar xvf hadoop-3.3.0.tar.gz
+  mv spark-3.0.2-bin-without-hadoop/ /opt/spark
+  cd /opt/spark/conf
+  mv spark-env.sh.template spark-env.sh
+  export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
+  export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
+  export SPARK_HOME=/opt/spark
+  export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
+  start-master.sh
+  start-slave.sh spark://localhost:7077
+  cd ../../../spark-connector/examples
+  spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-1.0.jar sparkapp.py
+
+fi

--- a/examples/pyspark/sparkapp.py
+++ b/examples/pyspark/sparkapp.py
@@ -2,13 +2,15 @@ from pyspark import SparkContext, SparkConf
 from pyspark.sql import SQLContext, SparkSession
 from pyspark import sql
 
+# Create the spark session
 spark = SparkSession \
     .builder \
     .appName("Vertica Connector Pyspark Example App") \
     .getOrCreate()
-sc = spark.sparkContext
-sqlContext = sql.SQLContext(sc)
+spark_context = spark.sparkContext
+sql_context = sql.SQLContext(spark_context)
 
+# Set connector options based on our Docker setup
 host="vertica"
 user="dbadmin"
 password=""
@@ -16,11 +18,14 @@ db="docker"
 staging_fs_url="hdfs://hdfs:8020/data/dirtest"
 table="pysparktest"
 
-# Write data to table
+# Define data to write to Vertica
 columns = ["language","users_count"]
 data = [("Java", "20000"), ("Python", "100000"), ("Scala", "3000")]
-rdd = sc.parallelize(data)
+# Create an RDD from the data
+rdd = spark_context.parallelize(data)
+# Convert the RDD to a DataFrame
 df = rdd.toDF(columns)
+# Write the DataFrame to the Vertica table pysparktest
 df.write.mode('overwrite').save(format="com.vertica.spark.datasource.VerticaSource",
  host="vertica",
  user="dbadmin",
@@ -29,7 +34,7 @@ df.write.mode('overwrite').save(format="com.vertica.spark.datasource.VerticaSour
  staging_fs_url="hdfs://hdfs:8020/data/dirtest",
  table="pysparktest")
 
-# Read back into Spark
+# Read the data back into a Spark DataFrame
 readDf = spark.read.load(format="com.vertica.spark.datasource.VerticaSource",
  host="vertica",
  user="dbadmin",
@@ -37,4 +42,5 @@ readDf = spark.read.load(format="com.vertica.spark.datasource.VerticaSource",
  db="docker",
  table="pysparktest",
  staging_fs_url="hdfs://hdfs:8020/data/dirtest")
+# Print the DataFrame contents
 print(readDf.rdd.collect())

--- a/examples/s3-example/README.md
+++ b/examples/s3-example/README.md
@@ -52,6 +52,6 @@ docker compose up -d
 ```
 Run `docker exec -it docker_client_1 /bin/bash` to enter the sandbox client environment. The following steps assume you are in this container.
 
-You should now be able to run the example: `./run-example.sh`
+You should now be able to run the example: `./run-example.sh target/scala-2.12/spark-vertica-connector-s3-example-assembly-1.0.jar`
 
 If you get a permission denied issue, run `chmod +x run-example.sh`

--- a/examples/s3-example/README.md
+++ b/examples/s3-example/README.md
@@ -45,12 +45,12 @@ In the project's root directory (spark-connector/examples/s3-example) , run `sbt
 sbt assembly
 ```
 
-Change directory to docker:
+Change directory to docker and run sandbox-clientenv.sh:
 ```
 cd ../../spark-connector/docker
-docker compose up -d
+./sandbox-clientenv.sh
 ```
-Run `docker exec -it docker_client_1 /bin/bash` to enter the sandbox client environment. The following steps assume you are in this container.
+This will put you in the sandbox client environment. The following steps assume you are in this container.
 
 You should now be able to run the example: `./run-example.sh target/scala-2.12/spark-vertica-connector-s3-example-assembly-1.0.jar`
 


### PR DESCRIPTION
### Summary

This change updates documentation and scripts for the PySpark example.

### Description

This change adds automation for the PySpark example to make it easier to run. Previously, we didn't install Python3 or setup the Spark cluster, so this makes it easier to get started. It also adds comments to the Python script to make it easier for people unfamiliar with PySpark to understand what the script is doing. In addition, the READMEs for PySpark and for the examples in general have both been updated.

No changes were required for S3, aside from the README. Apparently, the "bad array subscript" issue I get is only happening for me, and only sometimes. I'll likely need to dig into it a bit more, but for now, this should work fine.

### Related Issue

VER-77686

### Additional Reviewers

@alexr-bq 
@ravjotbrar 
