### PR TITLE
Change examples and functional tests to use webhdfs instead of hdfs

### DIFF
--- a/examples/basic-read/src/main/resources/application.conf
+++ b/examples/basic-read/src/main/resources/application.conf
@@ -5,7 +5,6 @@ functional-tests {
   user="dbadmin"
   password=""
   log=true
-  filepath="hdfs://hdfs:8020/data/"
-  dirpath="hdfs://hdfs:8020/data/dirtest/"
+  filepath="webhdfs://hdfs:50070/data/"
 }
 

--- a/examples/basic-write/src/main/resources/application.conf
+++ b/examples/basic-write/src/main/resources/application.conf
@@ -5,7 +5,6 @@ functional-tests {
   user="dbadmin"
   password=""
   log=true
-  filepath="hdfs://hdfs:8020/data/"
-  dirpath="hdfs://hdfs:8020/data/dirtest/"
+  filepath="webhdfs://hdfs:50070/data/"
 }
 

--- a/examples/demo/src/main/resources/application.conf
+++ b/examples/demo/src/main/resources/application.conf
@@ -5,7 +5,6 @@ functional-tests {
   user="dbadmin"
   password=""
   log=true
-  filepath="hdfs://hdfs:8020/data/"
-  dirpath="hdfs://hdfs:8020/data/dirtest/"
+  filepath="webhdfs://hdfs:50070/data/"
 }
 

--- a/examples/kerberos-example/src/main/resources/application.conf
+++ b/examples/kerberos-example/src/main/resources/application.conf
@@ -4,8 +4,7 @@ functional-tests {
   db="docker"
   user="user1"
   log=true
-  filepath="hdfs://hdfs.example.com:8020/data/"
-  dirpath="hdfs://hdfs.example.com:8020/data/dirtest/"
+  filepath="swebhdfs://hdfs.example.com:50070/data/"
   kerberos_service_name="vertica"
   kerberos_host_name="vertica.example.com"
   jaas_config_name="Client"

--- a/examples/pyspark/sparkapp.py
+++ b/examples/pyspark/sparkapp.py
@@ -31,7 +31,7 @@ df.write.mode('overwrite').save(format="com.vertica.spark.datasource.VerticaSour
  user="dbadmin",
  password="",
  db="docker",
- staging_fs_url="hdfs://hdfs:8020/data/dirtest",
+ staging_fs_url="webhdfs://hdfs:50070/data/dirtest",
  table="pysparktest")
 
 # Read the data back into a Spark DataFrame

--- a/functional-tests/s3-functional-tests.sh
+++ b/functional-tests/s3-functional-tests.sh
@@ -1,4 +1,4 @@
-wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.2/spark-3.0.2-bin-without-hadoop.tgz
+wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.3/spark-3.0.3-bin-without-hadoop.tgz
 wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
 cd ../../
 tar xvf spark-3.0.2-bin-without-hadoop.tgz

--- a/functional-tests/s3-functional-tests.sh
+++ b/functional-tests/s3-functional-tests.sh
@@ -1,9 +1,9 @@
 wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.3/spark-3.0.3-bin-without-hadoop.tgz
 wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
 cd ../../
-tar xvf spark-3.0.2-bin-without-hadoop.tgz
+tar xvf spark-3.0.3-bin-without-hadoop.tgz
 tar xvf hadoop-3.3.0.tar.gz
-mv spark-3.0.2-bin-without-hadoop/ /opt/spark
+mv spark-3.0.3-bin-without-hadoop/ /opt/spark
 cd /opt/spark/conf
 mv spark-env.sh.template spark-env.sh
 export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk

--- a/functional-tests/src/main/resources/application.conf
+++ b/functional-tests/src/main/resources/application.conf
@@ -5,7 +5,7 @@ functional-tests {
   user="dbadmin"
   password=""
   log=true
-  filepath="hdfs://hdfs:8020/data/"
+  filepath="webhdfs://hdfs:50070/data/"
   tlsmode="disable"
   truststorepath="/truststore.jks"
   truststorepassword="dbadmin"


### PR DESCRIPTION
### Summary

Change tests and examples to use webhdfs as that should be the new default.

### Related Issue

https://github.com/vertica/spark-connector/issues/119

### Additional Reviewers

@jonathanl-bq 
@ravjotbrar 