### PR TITLE
Merge statement prototype

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/config/WriteConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/WriteConfig.scala
@@ -72,6 +72,7 @@ object ValidColumnList {
  * @param copyColumnList Optional list of columns to use in copy statement.
  * @param sessionId Unqiue identifier for this write operation.
  * @param failedRowPercentTolerance Value between 0 and 1, percent of rows that are allowed to fail before the operation fails.
+ * @param mergeKey Key that two data sets are joined on in order to execute a merge statement
  */
 final case class DistributedFilesystemWriteConfig(jdbcConfig: JDBCConfig,
                                                   fileStoreConfig: FileStoreConfig,
@@ -82,7 +83,8 @@ final case class DistributedFilesystemWriteConfig(jdbcConfig: JDBCConfig,
                                                   copyColumnList: Option[ValidColumnList],
                                                   sessionId: String,
                                                   failedRowPercentTolerance: Float,
-                                                  filePermissions: ValidFilePermissions
+                                                  filePermissions: ValidFilePermissions,
+                                                  mergeKey: Option[String]
                                                  ) extends WriteConfig {
   private var overwrite: Boolean = false
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/VerticaDatasourceV2.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/VerticaDatasourceV2.scala
@@ -30,7 +30,7 @@ import collection.JavaConverters._
  *
  * Implements Spark V2 datasource class [[http://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/connector/catalog/TableProvider.html here]]
  *
- * This and the tree of classes returned by is are to be kept light, and hook into the core of the connector
+ * This and the tree of classes returned by it are to be kept light, and hook into the core of the connector
  */
 class VerticaSource extends TableProvider with SupportsCatalogOptions {
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
@@ -362,6 +362,10 @@ object DSConfigSetupUtils {
     }
   }
 
+  def getMergeKey(config: Map[String, String]) : ValidationResult[Option[String]] = {
+    config.get("merge_key").validNec
+  }
+
   def validateAndGetJDBCAuth(config: Map[String, String]): DSConfigSetupUtils.ValidationResult[JdbcAuth] = {
     val user = DSConfigSetupUtils.getUser(config)
     val password = DSConfigSetupUtils.getPassword(config)
@@ -537,7 +541,8 @@ class DSWriteConfigSetup(val schema: Option[StructType], val pipeFactory: Vertic
           DSConfigSetupUtils.getCopyColumnList(config),
           sessionId.validNec,
           DSConfigSetupUtils.getFailedRowsPercentTolerance(config),
-          DSConfigSetupUtils.getFilePermissions(config)
+          DSConfigSetupUtils.getFilePermissions(config),
+          DSConfigSetupUtils.getMergeKey(config)
         ).mapN(DistributedFilesystemWriteConfig)
       case None =>
         MissingSchemaError().invalidNec

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -45,6 +45,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
           extends VerticaPipeInterface with VerticaPipeWriteInterface {
 
   private val logger = LogProvider.getLogger(classOf[VerticaDistributedFilesystemWritePipe])
+  private val tempTableName = new TableName(config.tablename.name + "_" + config.sessionId, None)
 
   /**
    * No write metadata required for configuration as of yet.
@@ -105,7 +106,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
       // Overwrite safety check
       _ <- if (config.isOverwrite && tableExistsPre) Left(DropTableError()) else Right(())
 
-      // Check if a view exists or temp table exits by this name
+      // Check if a view exists or temp table exists by this name
       viewExists <- tableUtils.viewExists(config.tablename)
       _ <- if (viewExists) Left(ViewExistsError()) else Right(())
       tempTableExists <- tableUtils.tempTableExists(config.tablename)
@@ -116,6 +117,9 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
       // Confirm table was created. This should only be false if the user specified an invalid target_table_sql
       tableExistsPost <- tableUtils.tableExists(config.tablename)
       _ <- if (tableExistsPost) Right(()) else Left(CreateTableError(None))
+
+      // Check if merge key was passed in. If so, this creates a temporary table, which will be merged into the target table.
+      _ <- if (config.mergeKey.isDefined) tableUtils.createTable(tempTableName, None, config.schema, config.strlen) else Right(())
 
       // Create the directory to export files to
       perm = config.filePermissions
@@ -145,6 +149,32 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
 
   def buildCopyStatement(targetTable: String, columnList: String, url: String, rejectsTableName: String, fileFormat: String): String = {
     s"COPY $targetTable $columnList FROM '$url' ON ANY NODE $fileFormat REJECTED DATA AS TABLE $rejectsTableName NO COMMIT"
+  }
+
+  def buildMergeStatement(targetTableName: TableName, columnList: String, tempTable: String, mergeKey: Option[String]): String = {
+    var targetTable = targetTableName.getFullTableName
+    val updateColValues = schemaTools.getUpdateValues(jdbcLayer, targetTableName)
+    val insertColValues = schemaTools.getInsertValues(jdbcLayer, targetTableName)
+    val mergeKeyString = mergeKey match {
+      case Some(key) => key
+      case None => None
+    }
+    s"MERGE INTO $targetTable as target using $tempTable as temp ON (target.$mergeKeyString=temp.$mergeKeyString) WHEN MATCHED THEN UPDATE SET $updateColValues WHEN NOT MATCHED THEN INSERT $columnList VALUES $insertColValues"
+  }
+
+  def performMerge (mergeStatement: String): ConnectorResult[Int] = {
+    val ret = for {
+
+      // Explain merge first to verify it's valid.
+      rs <- jdbcLayer.query("EXPLAIN " + mergeStatement)
+      _ = rs.close()
+
+      // Real merge
+      rowsCopied <- jdbcLayer.executeUpdate(mergeStatement)
+    } yield rowsCopied
+    logger.info("Executing Merge")
+    ret.left.map(err => CommitError(err).context("performMerge: JDBC error when trying to merge"))
+
   }
 
   /**
@@ -238,7 +268,6 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
     // Empty copy to make sure a projection is created if it hasn't been yet
     // This will error out, but create the projection
     val emptyCopy = "COPY " + tablename.getFullTableName + " FROM '';"
-
     jdbcLayer.executeUpdate(emptyCopy)
 
     val ret = for {
@@ -259,9 +288,11 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
 
     // Create url string, escape any ' characters as those surround the url
     val url: String = EscapeUtils.sqlEscape(s"${config.fileStoreConfig.address.stripSuffix("/")}/$globPattern")
-
-    val tableNameMaxLength = 30
-
+    val mergeKey= config.mergeKey match{
+      case Some(mergeKey) => true
+      case None => false
+    }
+    if(mergeKey) logger.info("Merge should take place") else logger.info("Merge key does not exist")
     val ret = for {
       // Set Vertica to work with kerberos and HDFS/AWS
       _ <- jdbcLayer.configureSession(fileStoreLayer)
@@ -269,8 +300,13 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
       // Get columnList
       columnList <- getColumnList.left.map(_.context("commit: Failed to get column list"))
 
+      // Do not check for mergeKey here, as tableName does not impact merge
       tableName = config.tablename.name
+
+      tableNameMaxLength = 30
+
       sessionId = config.sessionId
+
       rejectsTableName = "\"" +
         EscapeUtils.sqlEscape(tableName.substring(0,Math.min(tableNameMaxLength,tableName.length))) +
         "_" +
@@ -278,21 +314,27 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
         "_COMMITS" +
         "\""
 
-      copyStatement = buildCopyStatement(config.tablename.getFullTableName,
+      fullTableName <- if(config.mergeKey.isDefined) Right(tempTableName.getFullTableName) else Right(config.tablename.getFullTableName)
+
+      copyStatement = buildCopyStatement(fullTableName.toString(),
         columnList,
         url,
         rejectsTableName,
         "parquet"
       )
 
-      rowsCopied <- performCopy(copyStatement, config.tablename).left.map(_.context("commit: Failed to copy rows"))
+      rowsCopied <- if (config.mergeKey.isDefined) Right(performCopy(copyStatement, tempTableName).left.map(_.context("commit: Failed to copy rows"))) else Right(performCopy(copyStatement, config.tablename).left.map(_.context("commit: Failed to copy rows")))
 
-      faultToleranceResults <- testFaultTolerance(rowsCopied, rejectsTableName)
+      faultToleranceResults <- testFaultTolerance(rowsCopied.right.getOrElse(0), rejectsTableName)
         .left.map(err => CommitError(err).context("commit: JDBC Error when trying to determine fault tolerance"))
 
       _ <- tableUtils.updateJobStatusTable(config.tablename, config.jdbcConfig.auth.user, faultToleranceResults.failedRowsPercent, config.sessionId, faultToleranceResults.success)
 
       _ <- if (faultToleranceResults.success) Right(()) else Left(FaultToleranceTestFail())
+
+      mergeStatement = buildMergeStatement(config.tablename, columnList, tempTableName.getFullTableName, config.mergeKey)
+      rowsMerged <- if (config.mergeKey.isDefined) performMerge(mergeStatement) else Right(())
+
     } yield ()
 
     // Commit or rollback

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -285,7 +285,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
 
   def commit(): ConnectorResult[Unit] = {
     val globPattern: String = "*.parquet"
-
+    val tableNameMaxLength = 30
     // Create url string, escape any ' characters as those surround the url
     val url: String = EscapeUtils.sqlEscape(s"${config.fileStoreConfig.address.stripSuffix("/")}/$globPattern")
     val mergeKey= config.mergeKey match{
@@ -302,9 +302,6 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
 
       // Do not check for mergeKey here, as tableName does not impact merge
       tableName = config.tablename.name
-
-      tableNameMaxLength = 30
-
       sessionId = config.sessionId
 
       rejectsTableName = "\"" +

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/DSWriterTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/DSWriterTest.scala
@@ -41,7 +41,8 @@ class DSWriterTest extends AnyFlatSpec with BeforeAndAfterAll with MockFactory {
     copyColumnList = None,
     sessionId = "id",
     failedRowPercentTolerance =  0.0f,
-    filePermissions = ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")))
+    filePermissions = ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")),
+    mergeKey = None)
 
   val uniqueId = "unique-id"
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -49,7 +49,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
       copyColumnList = None,
       sessionId = "id",
       0.0f,
-      ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")))
+      ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")),
+      mergeKey = None)
   }
 
   private def checkResult(result: ConnectorResult[Unit]): Unit = {
@@ -294,6 +295,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
     (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
+    (schemaToolsInterface.getUpdateValues _).expects(jdbcLayerInterface, tablename).returning("")
+    (schemaToolsInterface.getInsertValues _).expects(jdbcLayerInterface, tablename).returning("")
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -321,6 +324,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.execute _).expects(*, *).returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
     val schemaToolsInterface = mock[SchemaToolsInterface]
+    (schemaToolsInterface.getUpdateValues _).expects(jdbcLayerInterface, tablename).returning("")
+    (schemaToolsInterface.getInsertValues _).expects(jdbcLayerInterface, tablename).returning("")
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -339,6 +344,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.configureSession _).expects(*).returning(Right(()))
     (jdbcLayerInterface.executeUpdate _).expects(*, *).returning(Right(1))
+    (jdbcLayerInterface.query _).expects(*, *).returning(Left(SyntaxError(new Exception())))
     (jdbcLayerInterface.query _).expects(*, *).returning(Left(SyntaxError(new Exception())))
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
     (jdbcLayerInterface.close _).expects().returning(Right(()))
@@ -377,6 +383,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
     (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
+    (schemaToolsInterface.getUpdateValues _).expects(jdbcLayerInterface, tablename).returning("")
+    (schemaToolsInterface.getInsertValues _).expects(jdbcLayerInterface, tablename).returning("")
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(fileStoreConfig.address).returning(Right())
@@ -406,6 +414,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
+    (schemaToolsInterface.getUpdateValues _).expects(jdbcLayerInterface, tablename).returning("")
+    (schemaToolsInterface.getInsertValues _).expects(jdbcLayerInterface, tablename).returning("")
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -433,6 +443,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
     (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right("(\"col1\",\"col5\")"))
+    (schemaToolsInterface.getUpdateValues _).expects(jdbcLayerInterface, tablename).returning("")
+    (schemaToolsInterface.getInsertValues _).expects(jdbcLayerInterface, tablename).returning("")
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -493,6 +505,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
     (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
+    (schemaToolsInterface.getUpdateValues _).expects(jdbcLayerInterface, tablename).returning("")
+    (schemaToolsInterface.getInsertValues _).expects(jdbcLayerInterface, tablename).returning("")
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())
@@ -525,6 +539,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
     (schemaToolsInterface.getCopyColumnList _).expects(jdbcLayerInterface, tablename, schema).returning(Right(""))
+    (schemaToolsInterface.getUpdateValues _).expects(jdbcLayerInterface, tablename).returning("")
+    (schemaToolsInterface.getInsertValues _).expects(jdbcLayerInterface, tablename).returning("")
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right())

--- a/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
@@ -76,7 +76,8 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
     copyColumnList = None,
     sessionId = "id",
     failedRowPercentTolerance =  0.0f,
-    filePermissions = ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")))
+    filePermissions = ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")),
+    mergeKey = None)
 
   val intSchema = new StructType(Array(StructField("col1", IntegerType)))
 

--- a/examples/merge-example/build.sbt
+++ b/examples/merge-example/build.sbt
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 scalaVersion := "2.12.12"
-name := "spark-vertica-connector-basic-write"
+name := "spark-vertica-connector-merge-example"
 organization := "com.vertica"
 version := "2.0"
 
@@ -23,7 +23,6 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
 )
 
 assemblyMergeStrategy in assembly := {

--- a/examples/merge-example/src/main/resources/application.conf
+++ b/examples/merge-example/src/main/resources/application.conf
@@ -1,0 +1,11 @@
+functional-tests {
+  host="vertica"
+  port=5433
+  db="docker"
+  user="dbadmin"
+  password=""
+  log=true
+  filepath="hdfs://hdfs:8020/data/"
+  merge_key="col1"
+}
+

--- a/examples/merge-example/src/main/scala/example/Main.scala
+++ b/examples/merge-example/src/main/scala/example/Main.scala
@@ -1,0 +1,71 @@
+// (c) Copyright [2020-2021] Micro Focus or one of its affiliates.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package example
+
+import java.sql.Connection
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.Config
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+
+object Main  {
+  def main(args: Array[String]): Unit = {
+    val conf: Config = ConfigFactory.load()
+
+    // Configuration options for the connector
+    val writeOpts = Map(
+      "host" -> conf.getString("functional-tests.host"),
+      "user" -> conf.getString("functional-tests.user"),
+      "db" -> conf.getString("functional-tests.db"),
+      "staging_fs_url" -> conf.getString("functional-tests.filepath"),
+      "password" -> conf.getString("functional-tests.password"),
+      "logging_level" -> {if(conf.getBoolean("functional-tests.log")) "DEBUG" else "OFF"},
+      "merge_key" -> conf.getString("functional-tests.merge_key")
+    )
+
+    val conn: Connection = TestUtils.getJDBCConnection(writeOpts("host"), db = writeOpts("db"), user = writeOpts("user"), password = writeOpts("password"))
+    // Entry-point to all functionality in Spark
+    val spark = SparkSession.builder()
+      .master("local[*]")
+      .appName("Vertica Connector Test Prototype")
+      .getOrCreate()
+
+    try {
+      val tableName = "dftest"
+      val stmt = conn.createStatement
+      val n = 20
+      // Creates a table called dftest with an integer attribute
+      TestUtils.createTableBySQL(conn, tableName, "create table " + tableName + "(col1 int, col2 varchar(50))")
+      val insert = "insert into " + tableName + " values(2, 'hi')"
+      // Inserts 20 rows of the value '2' into dftest
+      TestUtils.populateTableBySQL(stmt, insert, n)
+
+      // Define schema of a table
+      val schema = new StructType(Array(StructField("col1", IntegerType), StructField("col2", StringType)))
+      val data = (1 to 20).map(x => Row(x, "test"))
+      // Create a dataframe corresponding to the schema and data specified above
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+      val mode = SaveMode.Append
+      // Write dataframe to Vertica
+      df.write.format("com.vertica.spark.datasource.VerticaSource").options(writeOpts + ("table" -> tableName)).mode(mode).save()
+
+      val df2: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(writeOpts + ("table" -> tableName)).load()
+      df2.rdd.foreach(x => println("VALUE: " + x))
+
+    } finally {
+      spark.close()
+    }
+  }
+}

--- a/examples/merge-example/src/main/scala/example/TestUtils.scala
+++ b/examples/merge-example/src/main/scala/example/TestUtils.scala
@@ -1,0 +1,110 @@
+// (c) Copyright [2020-2021] Micro Focus or one of its affiliates.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package example
+
+import java.sql.{Connection, DriverManager, Statement}
+import java.util.Properties
+import org.apache.spark.sql.SparkSession
+
+object TestUtils {
+  def getJDBCConnection(host: String, port: Int = 5433, db: String, user: String, password: String): Connection = {
+    Class.forName("com.vertica.jdbc.Driver").newInstance()
+
+    val prop = new Properties()
+    prop.put("user", user)
+    prop.put("password", password)
+
+    getConnectionByProp(host, port, db, prop)(None)
+  }
+
+  def getJDBCUrl(host: String, port: Int = 5433, db: String): String = {
+    "jdbc:vertica://" + host + ":" + port + "/" + db
+  }
+
+  def getConnectionByProp(host: String, port: Int = 5433, db: String, prop: Properties)(overrideHost: Option[String]): Connection = {
+    Class.forName("com.vertica.jdbc.Driver").newInstance()
+
+    val h = overrideHost match {
+      case Some(m) => m
+      case None    => host
+    }
+    prop.setProperty("host", h)
+    val jdbcURI = getJDBCUrl(h, port, db)
+    DriverManager.getConnection(jdbcURI, prop)
+
+  }
+
+  def createTableBySQL(conn: Connection, tableName: String, createTableStr: String): Boolean = {
+    val stmt = conn.createStatement()
+
+    stmt.execute("drop table if exists " + tableName)
+    println(createTableStr)
+    stmt.execute(createTableStr)
+  }
+
+  def createTable(conn: Connection, tableName: String, isSegmented: Boolean = true, numOfRows: Int = 10): Unit = {
+    val stmt = conn.createStatement()
+    stmt.execute("drop table if exists " + tableName)
+    val createStr = "create table " + tableName + "(a int, b int) " +
+      (if (isSegmented) "segmented by hash(a)" else "unsegmented") + " all nodes;"
+    println(createStr)
+    stmt.execute(createStr)
+    populateTable(stmt, tableName, numOfRows)
+  }
+
+  private def populateTable(stmt: Statement, tableName: String, numOfRows: Int) {
+    for (i <- 0 until numOfRows) {
+      val insertStr = "insert into " + tableName + " values (" + i + " ," + i + ")"
+      println(insertStr)
+      stmt.execute(insertStr)
+    }
+  }
+
+  def populateTableBySQL(stmt: Statement, insertStr: String, numOfRows: Int) {
+    for (_ <- 0 until numOfRows) {
+      stmt.execute(insertStr)
+    }
+  }
+
+  def doCount(spark: SparkSession, opt:Map[String, String]):Long = {
+    val df = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(opt).load()
+
+    df.cache()
+    df.show()
+    println("schema =" + df.schema)
+    val c = df.count()
+    println("count = " + c)
+    c
+  }
+
+  def createTablePartialNodes(conn: Connection, tableName: String, isSegmented: Boolean = true, numOfRows: Int = 10, nodes: List[String]): Unit = {
+    val stmt = conn.createStatement()
+    stmt.execute("drop table if exists " + tableName)
+    val createStr = "create table if not exists " + tableName + "(a int, b int) " +
+      (if (isSegmented) "segmented by hash(a)" + " nodes " + nodes.mkString(",")
+      else " UNSEGMENTED node " + nodes.head + " KSAFE 0") + ";"
+    println(createStr)
+    stmt.execute(createStr)
+    populateTable(stmt, tableName, numOfRows)
+  }
+
+  def getNodeNames(conn: Connection): List[String] = {
+    val nodeQry = "select node_name from nodes;"
+    val rs = conn.createStatement().executeQuery(nodeQry)
+    new Iterator[String] {
+      def hasNext: Boolean = rs.next()
+      def next(): String = rs.getString(1)
+    }.toList
+  }
+}

--- a/examples/run-example.sh
+++ b/examples/run-example.sh
@@ -1,11 +1,11 @@
 if [ "$1" == "clean" ]
   then
-    wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.2/spark-3.0.2-bin-without-hadoop.tgz
+    wget -P ../../ https://mirror.dsrg.utoronto.ca/apache/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
     wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
     cd ../../
-    tar xvf spark-3.0.2-bin-without-hadoop.tgz
+    tar xvf spark-3.1.2-bin-without-hadoop.tgz
     tar xvf hadoop-3.3.0.tar.gz
-    mv spark-3.0.2-bin-without-hadoop/ /opt/spark
+    mv spark-3.1.2-bin-without-hadoop/ /opt/spark
     cd /opt/spark/conf
     mv spark-env.sh.template spark-env.sh
     export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
@@ -26,12 +26,12 @@ elif [ -a ../../hadoop-3.3.0 ]
     spark-submit --master spark://localhost:7077 $1
 
 else
-  wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.2/spark-3.0.2-bin-without-hadoop.tgz
+  wget -P ../../ https://mirror.dsrg.utoronto.ca/apache/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
   wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
   cd ../../
-  tar xvf spark-3.0.2-bin-without-hadoop.tgz
+  tar xvf spark-3.1.2-bin-without-hadoop.tgz
   tar xvf hadoop-3.3.0.tar.gz
-  mv spark-3.0.2-bin-without-hadoop/ /opt/spark
+  mv spark-3.1.2-bin-without-hadoop/ /opt/spark
   cd /opt/spark/conf
   mv spark-env.sh.template spark-env.sh
   export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-EXPLAIN MERGE INTO dftest as target using dftest_e85027bb_1676_479c_afe5_4e9c5c62d8c7 as temp ON (target.col1=temp.col1) WHEN MATCHED THEN UPDATE SET target.col1=temp.col1, target.col2=temp.col2 WHEN NOT MATCHED THEN INSERT ("col1","col2") VALUES (temp.col1, temp.col2)

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+EXPLAIN MERGE INTO dftest as target using dftest_e85027bb_1676_479c_afe5_4e9c5c62d8c7 as temp ON (target.col1=temp.col1) WHEN MATCHED THEN UPDATE SET target.col1=temp.col1, target.col2=temp.col2 WHEN NOT MATCHED THEN INSERT ("col1","col2") VALUES (temp.col1, temp.col2)


### PR DESCRIPTION
### Summary

With the implementation of merge statements in our connector, users can process raw data in Spark and merge that data with an existing table in Vertica. The processed data will be written to a temporary table in Vertica before being merged. In the existing table, matched records will be updated and new records will be inserted, effectively constituting an “Upsert”. In order to execute a merge statement in our Spark Connector, the user needs to pass in a mergeKey, which will likely be an array of column attributes to join the existing table and temporary table on. If this option is not populated, a write will be performed as usual without the use of a temporary table.

### Description

For this prototype, changes were made to add a new connector option, which is used to pass in the merge key. When in the write pipe, the connector checks for the existence of this merge key, and if it exists, creates a temporary table which will be used for the intermediary copy. The write pipe then uses the JDBC layer to perform the merge from the temporary table into the target table. Two new supporting functions were implemented in SchemaTools to create the merge statement.

### Related Issue

https://github.com/vertica/spark-connector/issues/118

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
@alexey-temnikov 
