### PR TITLE
Add smart client label for JDBC connection

### DIFF
--- a/connector/build.sbt
+++ b/connector/build.sbt
@@ -83,3 +83,10 @@ envVars in Test := Map(
   "AWS_DEFAULT_REGION" -> "us-west-1",
   "AWS_CREDENTIALS_PROVIDER" -> "test-provider"
 )
+
+lazy val root = (project in file(".")).
+  enablePlugins(BuildInfoPlugin).
+  settings(
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "hello"
+  )

--- a/connector/build.sbt
+++ b/connector/build.sbt
@@ -88,5 +88,5 @@ lazy val root = (project in file(".")).
   enablePlugins(BuildInfoPlugin).
   settings(
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
-    buildInfoPackage := "hello"
+    buildInfoPackage := "buildinfo"
   )

--- a/connector/project/plugins.sbt
+++ b/connector/project/plugins.sbt
@@ -6,4 +6,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("com.github.mwz" % "sbt-sonar" % "2.2.0")
 addSbtPlugin("com.sksamuel.scapegoat" % "sbt-scapegoat" % "1.1.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 

--- a/connector/src/main/scala/com/vertica/spark/config/JDBCConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/JDBCConfig.scala
@@ -20,7 +20,7 @@ import com.vertica.spark.datasource.core.TLSMode
  *
  * Abstract as there are multiple possible methods of authentication.
  */
-trait JdbcAuth {
+sealed trait JdbcAuth {
   def user: String
 }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -295,6 +295,9 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
 
   def configureSession(fileStoreLayer: FileStoreLayerInterface): ConnectorResult[Unit] = {
     for {
+      connection <- this.connection
+      label <- Try{connection.getClientInfo("APPLICATIONNAME")}.toEither.left.map(e => handleJDBCException(e))
+      _ <- this.query(s"SELECT SET_CLIENT_LABEL('$label');")
       _ <- this.configureKerberosToFilestore(fileStoreLayer)
       _ <- this.configureAWSParameters(fileStoreLayer)
     } yield ()

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -24,6 +24,7 @@ import com.vertica.spark.config.{BasicJdbcAuth, JDBCConfig, KerberosAuth, LogPro
 import com.vertica.spark.datasource.fs.FileStoreLayerInterface
 import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
 import com.vertica.spark.util.general.Utils
+import hello.BuildInfo
 import org.apache.spark.sql.SparkSession
 
 import scala.util.Try
@@ -126,11 +127,20 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
       .toEither.left.map(handleConnectionException)
       .flatMap(conn =>
         this.useConnection(conn, c => {
-          c.setClientInfo("APPLICATIONNAME", "Vertica Spark Connector")
+          c.setClientInfo("APPLICATIONNAME", this.createClientLabel)
           c.setAutoCommit(false)
           logger.info("Successfully connected to Vertica.")
           c
         }, handleConnectionException).left.map(_.context("Initial connection was not valid.")))
+  }
+
+  private def createClientLabel: String = {
+    val authMethod = this.cfg.auth match {
+      case BasicJdbcAuth(_, _) => "-p"
+      case KerberosAuth(_, _, _, _) => "-k"
+    }
+    val sparkVersion = SparkSession.active.sparkContext.version
+    "vspark" + "-vs" + BuildInfo.version + authMethod + "-" + sparkVersion + "-" + java.util.UUID.randomUUID.toString
   }
 
   private def handleConnectionException(e: Throwable): ConnectorError = {

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -24,7 +24,7 @@ import com.vertica.spark.config.{BasicJdbcAuth, JDBCConfig, KerberosAuth, LogPro
 import com.vertica.spark.datasource.fs.FileStoreLayerInterface
 import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
 import com.vertica.spark.util.general.Utils
-import hello.BuildInfo
+import buildinfo.BuildInfo
 import org.apache.spark.sql.SparkSession
 
 import scala.util.Try
@@ -140,7 +140,7 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
       case KerberosAuth(_, _, _, _) => "-k"
     }
     val sparkVersion = SparkSession.active.sparkContext.version
-    "vspark" + "-vs" + BuildInfo.version + authMethod + "-sp" + sparkVersion + "-" + java.util.UUID.randomUUID.toString
+    "vspark" + "-vs" + BuildInfo.version + authMethod + "-sp" + sparkVersion
   }
 
   private def handleConnectionException(e: Throwable): ConnectorError = {

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -140,7 +140,7 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
       case KerberosAuth(_, _, _, _) => "-k"
     }
     val sparkVersion = SparkSession.active.sparkContext.version
-    "vspark" + "-vs" + BuildInfo.version + authMethod + "-" + sparkVersion + "-" + java.util.UUID.randomUUID.toString
+    "vspark" + "-vs" + BuildInfo.version + authMethod + "-sp" + sparkVersion + "-" + java.util.UUID.randomUUID.toString
   }
 
   private def handleConnectionException(e: Throwable): ConnectorError = {

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -295,9 +295,6 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
 
   def configureSession(fileStoreLayer: FileStoreLayerInterface): ConnectorResult[Unit] = {
     for {
-      connection <- this.connection
-      label <- Try{connection.getClientInfo("APPLICATIONNAME")}.toEither.left.map(e => handleJDBCException(e))
-      _ <- this.query(s"SELECT SET_CLIENT_LABEL('$label');")
       _ <- this.configureKerberosToFilestore(fileStoreLayer)
       _ <- this.configureAWSParameters(fileStoreLayer)
     } yield ()

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -126,6 +126,7 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
       .toEither.left.map(handleConnectionException)
       .flatMap(conn =>
         this.useConnection(conn, c => {
+          c.setClientInfo("APPLICATIONNAME", "Vertica Spark Connector")
           c.setAutoCommit(false)
           logger.info("Successfully connected to Vertica.")
           c

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -27,7 +27,7 @@ import com.vertica.spark.util.error.{ConnectionSqlError, DataError, SyntaxError}
   * Should ensure that the component correctly passes on queries / other statements to vertica and correctly returns results. It should also confirm that error handling works as expected.
   */
 class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfterEach {
-  var jdbcLayer : JdbcLayerInterface = _
+  var jdbcLayer: JdbcLayerInterface = _
 
   val tablename = "test_table"
 
@@ -38,6 +38,7 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
   override def beforeEach(): Unit = {
     jdbcLayer.execute("DROP TABLE IF EXISTS " + tablename + ";")
   }
+
   override def afterEach(): Unit = {
     jdbcLayer.execute("DROP TABLE IF EXISTS " + tablename + ";")
   }
@@ -45,11 +46,11 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
   it should "Create a table" in {
     jdbcLayer.execute("CREATE TABLE " + tablename + "(vendor_key integer, vendor_name varchar(64));")
 
-    try{
+    try {
       jdbcLayer.query("SELECT * FROM " + tablename + " WHERE 1=0;")
     }
     catch {
-      case _ : Throwable => fail // There should be no error loading the created table
+      case _: Throwable => fail // There should be no error loading the created table
     }
   }
 
@@ -176,7 +177,7 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
 
   it should "Fail to connect to the wrong database" in {
     val tlsConfig = JDBCTLSConfig(tlsMode = Disable, None, None, None, None)
-    val badJdbcLayer = new VerticaJdbcLayer(JDBCConfig(host = jdbcCfg.host, port = jdbcCfg.port, db = jdbcCfg.db+"-doesnotexist123asdf", BasicJdbcAuth( username = "test", password = "test"), tlsConfig))
+    val badJdbcLayer = new VerticaJdbcLayer(JDBCConfig(host = jdbcCfg.host, port = jdbcCfg.port, db = jdbcCfg.db + "-doesnotexist123asdf", BasicJdbcAuth(username = "test", password = "test"), tlsConfig))
 
     badJdbcLayer.execute("CREATE TABLE " + tablename + "(name integer);") match {
       case Right(u) => assert(false) // should not succeed
@@ -190,5 +191,13 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
     }
   }
 
-
+  it should "Insert integer data with param" in {
+    jdbcLayer.query("GET_CLIENT_LABEL();") match {
+      case Right(rs) =>
+        assert(rs.next())
+        assert(rs.getString(1) == "Vertica Spark Connector")
+      case Left(err) =>
+        fail(err.getFullContext)
+    }
+  }
 }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -191,11 +191,14 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
     }
   }
 
-  it should "Insert integer data with param" in {
-    jdbcLayer.query("GET_CLIENT_LABEL();") match {
+  it should "get the client label" in {
+    val result = jdbcLayer.query("SELECT GET_CLIENT_LABEL();")
+
+    result match {
       case Right(rs) =>
         assert(rs.next())
-        assert(rs.getString(1) == "Vertica Spark Connector")
+        val label = rs.getString(1)
+        assert(label.contains("vspark-vs2.0.0-p-sp3.0.2"))
       case Left(err) =>
         fail(err.getFullContext)
     }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -206,7 +206,7 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
       case Right(rs) =>
         assert(rs.next())
         val label = rs.getString(1)
-        assert(label.contains("vspark-vs2.0.0-p-sp3.0.0"))
+        assert(label.contains("vspark-vs2.0.0-p-sp" + SparkSession.active.sparkContext.version))
       case Left(err) =>
         fail(err.getFullContext)
     }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -21,6 +21,7 @@ import com.vertica.spark.config.{BasicJdbcAuth, JDBCConfig, JDBCTLSConfig}
 import com.vertica.spark.datasource.core.Disable
 import com.vertica.spark.util.error.{ConnectionSqlError, DataError, SyntaxError}
 import org.apache.spark.sql.SparkSession
+import buildinfo.BuildInfo
 
 /**
   * Tests basic functionality of the VerticaJdbcLayer
@@ -206,7 +207,7 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
       case Right(rs) =>
         assert(rs.next())
         val label = rs.getString(1)
-        assert(label.contains("vspark-vs2.0.0-p-sp" + SparkSession.active.sparkContext.version))
+        assert(label.contains("vspark-vs" + BuildInfo.version + "-p-sp" + SparkSession.active.sparkContext.version))
       case Left(err) =>
         fail(err.getFullContext)
     }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -20,6 +20,7 @@ import com.vertica.spark.datasource.jdbc._
 import com.vertica.spark.config.{BasicJdbcAuth, JDBCConfig, JDBCTLSConfig}
 import com.vertica.spark.datasource.core.Disable
 import com.vertica.spark.util.error.{ConnectionSqlError, DataError, SyntaxError}
+import org.apache.spark.sql.SparkSession
 
 /**
   * Tests basic functionality of the VerticaJdbcLayer
@@ -30,6 +31,13 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
   var jdbcLayer: JdbcLayerInterface = _
 
   val tablename = "test_table"
+
+  private val spark = SparkSession.builder()
+    .master("local[*]")
+    .appName("Vertica Connector Test Prototype")
+    .config("spark.executor.extraJavaOptions", "-Dcom.amazonaws.services.s3.enableV4=true")
+    .config("spark.driver.extraJavaOptions", "-Dcom.amazonaws.services.s3.enableV4=true")
+    .getOrCreate()
 
   override def beforeAll(): Unit = {
     jdbcLayer = new VerticaJdbcLayer(jdbcCfg)
@@ -198,7 +206,7 @@ class JDBCTests(val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfter
       case Right(rs) =>
         assert(rs.next())
         val label = rs.getString(1)
-        assert(label.contains("vspark-vs2.0.0-p-sp3.0.2"))
+        assert(label.contains("vspark-vs2.0.0-p-sp3.0.0"))
       case Left(err) =>
         fail(err.getFullContext)
     }


### PR DESCRIPTION
### Summary

This change adds a smart client label to expose more helpful debugging information.

### Description

This adds a smart client label. The label includes the version of the connector, the Spark version, the authentication method used, and a UUID for the connection.

### Related Issue
#115 

### Additional Reviewers
@alexr-bq 
@ravjotbrar 
