### PR TITLE
Update spark version in run-example script

### DIFF
--- a/examples/run-example.sh
+++ b/examples/run-example.sh
@@ -1,11 +1,11 @@
 if [ "$1" == "clean" ]
   then
-    wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.2/spark-3.0.2-bin-without-hadoop.tgz
+    wget -P ../../ https://mirror.dsrg.utoronto.ca/apache/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
     wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
     cd ../../
-    tar xvf spark-3.0.2-bin-without-hadoop.tgz
+    tar xvf spark-3.1.2-bin-without-hadoop.tgz
     tar xvf hadoop-3.3.0.tar.gz
-    mv spark-3.0.2-bin-without-hadoop/ /opt/spark
+    mv spark-3.1.2-bin-without-hadoop/ /opt/spark
     cd /opt/spark/conf
     mv spark-env.sh.template spark-env.sh
     export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
@@ -26,12 +26,12 @@ elif [ -a ../../hadoop-3.3.0 ]
     spark-submit --master spark://localhost:7077 $1
 
 else
-  wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.2/spark-3.0.2-bin-without-hadoop.tgz
+  wget -P ../../ https://mirror.dsrg.utoronto.ca/apache/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
   wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
   cd ../../
-  tar xvf spark-3.0.2-bin-without-hadoop.tgz
+  tar xvf spark-3.1.2-bin-without-hadoop.tgz
   tar xvf hadoop-3.3.0.tar.gz
-  mv spark-3.0.2-bin-without-hadoop/ /opt/spark
+  mv spark-3.1.2-bin-without-hadoop/ /opt/spark
   cd /opt/spark/conf
   mv spark-env.sh.template spark-env.sh
   export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
@@ -44,7 +44,3 @@ else
   spark-submit --master spark://localhost:7077 $1
 
 fi
-
-
-
-


### PR DESCRIPTION
### Summary

Update spark version in run-example script

### Description

Changed mirror site to download Spark 3.1.2 instead of 3.0.2.

### Related Issue

https://github.com/vertica/spark-connector/issues/140

### Additional Reviewers

@jonathanl-bq 
