### PR TITLE
Update Spark download mirror site

### DIFF
--- a/examples/pyspark/run-python-example.sh
+++ b/examples/pyspark/run-python-example.sh
@@ -1,7 +1,7 @@
 if [ "$1" == "clean" ]
   then
     yum install -y python3
-    wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.2/spark-3.0.2-bin-without-hadoop.tgz
+    wget -P ../../ https://archive.apache.org/dist/spark/spark-3.0.3/spark-3.0.3-bin-without-hadoop.tgz
     wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
     cd ../../
     tar xvf spark-3.0.2-bin-without-hadoop.tgz
@@ -28,7 +28,7 @@ elif [ -a ../../hadoop-3.3.0 ]
 
 else
   yum install -y python3
-  wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.2/spark-3.0.2-bin-without-hadoop.tgz
+  wget -P ../../ https://archive.apache.org/dist/spark/spark-3.0.3/spark-3.0.3-bin-without-hadoop.tgz
   wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
   cd ../../
   tar xvf spark-3.0.2-bin-without-hadoop.tgz

--- a/examples/run-example.sh
+++ b/examples/run-example.sh
@@ -1,6 +1,6 @@
 if [ "$1" == "clean" ]
   then
-    wget -P ../../ https://mirror.dsrg.utoronto.ca/apache/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
+    wget -P ../../ https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
     wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
     cd ../../
     tar xvf spark-3.1.2-bin-without-hadoop.tgz
@@ -26,7 +26,7 @@ elif [ -a ../../hadoop-3.3.0 ]
     spark-submit --master spark://localhost:7077 $1
 
 else
-  wget -P ../../ https://mirror.dsrg.utoronto.ca/apache/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
+  wget -P ../../ https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
   wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
   cd ../../
   tar xvf spark-3.1.2-bin-without-hadoop.tgz

--- a/functional-tests/s3-functional-tests.sh
+++ b/functional-tests/s3-functional-tests.sh
@@ -1,4 +1,4 @@
-wget -P ../../ https://apache.mirror.colo-serv.net/spark/spark-3.0.3/spark-3.0.3-bin-without-hadoop.tgz
+wget -P ../../ https://archive.apache.org/dist/spark/spark-3.0.3/spark-3.0.3-bin-without-hadoop.tgz
 wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
 cd ../../
 tar xvf spark-3.0.3-bin-without-hadoop.tgz


### PR DESCRIPTION
### Summary

This change updates the mirror site from which we download Spark. 

### Description

All scripts now wget Spark from https://archive.apache.org/dist/spark/ for stability. 

### Related Issue

https://github.com/vertica/spark-connector/issues/152

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
