### PR TITLE
Fix sbt deprecation warnings

### DIFF
--- a/connector/build.sbt
+++ b/connector/build.sbt
@@ -30,9 +30,9 @@ libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.3.0"
 
-parallelExecution in Test := false
+Test / parallelExecution := false
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case n if n.contains("services") => MergeStrategy.concat
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
@@ -44,9 +44,9 @@ sonarProperties ++= Map(
   "sonar.host.url" -> "http://localhost:80",
 )
 
-scapegoatVersion in ThisBuild := "1.3.3"
+ThisBuild / scapegoatVersion := "1.3.3"
 scapegoatReports := Seq("xml")
-scalacOptions in Scapegoat += "-P:scapegoat:overrideLevels:all=Warning"
+Scapegoat / scalacOptions += "-P:scapegoat:overrideLevels:all=Warning"
 scalacOptions += "-Ypartial-unification"
 scalacOptions += "-Ywarn-value-discard"
 
@@ -63,20 +63,20 @@ coverageExcludedPackages := "<empty>;.*jdbc.*;.*fs.*;.*core.factory.*;.*parquet.
 coverageMinimum := 80
 coverageFailOnMinimum := true
 
-assemblyShadeRules in assembly := Seq(
+assembly / assemblyShadeRules := Seq(
   ShadeRule.rename("cats.**" -> "shadeCats.@1").inAll
 )
 
-assemblyExcludedJars in assembly := {
-  val cp = (fullClasspath in assembly).value
+assembly / assemblyExcludedJars := {
+  val cp = (assembly / fullClasspath).value
   cp.filter{f => f.data.getName.contains("spark") ||
               f.data.getName.contains("hadoop")
   }
 }
 
-fork in Test := true
+Test / fork := true
 
-envVars in Test := Map(
+Test / envVars := Map(
   "AWS_ACCESS_KEY_ID" -> "test",
   "AWS_SECRET_ACCESS_KEY" -> "foo",
   "AWS_SESSION_TOKEN" -> "testsessiontoken",

--- a/examples/basic-read-example/build.sbt
+++ b/examples/basic-read-example/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
 )
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }

--- a/examples/basic-write-example/build.sbt
+++ b/examples/basic-write-example/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
 )
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }

--- a/examples/kerberos-example/build.sbt
+++ b/examples/kerberos-example/build.sbt
@@ -26,9 +26,9 @@ libraryDependencies ++= Seq(
   "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
 )
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }
 
-unmanagedClasspath in Runtime += new File("/etc/hadoop/conf/")
+Runtime / unmanagedClasspath += new File("/etc/hadoop/conf/")

--- a/examples/merge-example/build.sbt
+++ b/examples/merge-example/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % "3.0.0",
 )
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }

--- a/examples/merge-example2/build.sbt
+++ b/examples/merge-example2/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % "3.0.0",
 )
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }

--- a/examples/s3-example/build.sbt
+++ b/examples/s3-example/build.sbt
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
   "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
 )
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }

--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -37,12 +37,12 @@ libraryDependencies += "org.typelevel" %% "cats-core" % "2.3.0"
 libraryDependencies += "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion
 libraryDependencies += "org.apache.hadoop" % "hadoop-aws" % "3.3.0"
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }
 
-assemblyShadeRules in assembly := Seq(
+assembly / assemblyShadeRules := Seq(
   ShadeRule.rename("cats.**" -> "shadeCats.@1").inAll
 )
 

--- a/performance-tests/build.sbt
+++ b/performance-tests/build.sbt
@@ -34,10 +34,10 @@ libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.3.0"
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }
 
-unmanagedClasspath in Runtime += new File("/etc/hadoop/etc/hadoop")
+Runtime / unmanagedClasspath += new File("/etc/hadoop/etc/hadoop")
 


### PR DESCRIPTION
### Summary

Since v1.5 sbt is becoming insistent about use of the ["unified slash syntax"](https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+to+slash+syntax) and issuing warnings on the good ol' `in` syntax.

In the interest of not being greeted with warnings immediately when you start to work on the project, let's make those go away.

### Description

Convert all scoped settings to use slash syntax.