### PR TITLE
Update kerberos example's conf and documentation

### DIFF
--- a/examples/kerberos-example/README.md
+++ b/examples/kerberos-example/README.md
@@ -32,9 +32,8 @@ Change directory to the example project:
 cd connector/spark-connector/examples/kerberos-example
 ```
 
-Run `sbt assembly` to build the assembly jar for this example (you may want to do this outside the container for a faster build).
-
 Run the example:
-`./run-example.sh target/scala-2.12/spark-vertica-connector-kerberos-example-assembly-1.0.jar`
 
-If you get a permission denied issue, run `chmod +x run-example.sh`
+`sbt run`
+
+

--- a/examples/kerberos-example/src/main/resources/application.conf
+++ b/examples/kerberos-example/src/main/resources/application.conf
@@ -4,7 +4,7 @@ functional-tests {
   db="docker"
   user="user1"
   log=true
-  filepath="swebhdfs://hdfs.example.com:50070/data/"
+  filepath="hdfs://hdfs.example.com:8020/data/"
   kerberos_service_name="vertica"
   kerberos_host_name="vertica.example.com"
   jaas_config_name="Client"


### PR DESCRIPTION
### Summary

Update kerberos example's conf and documentation

### Description

This change updates the filepath from webhdfs to hdfs and updates the kerberos example documentation to use sbt run instead of spark submit.

### Related Issue

https://github.com/vertica/spark-connector/issues/186

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
