### PR TITLE
Fix issue with duplicate IDs causing "File not found" error

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
@@ -43,7 +43,10 @@ trait ReadConfig {
 
   def getRequiredSchema: StructType
 
-  def copyConfig(newId: Boolean = false): ReadConfig
+  /**
+   * Copies the read config with a new unique identifier
+   */
+  def copyConfig(): ReadConfig
 }
 
 
@@ -111,11 +114,7 @@ final case class DistributedFilesystemReadConfig(
   def getPushdownFilters: List[PushdownFilter] = this.pushdownFilters
   def getRequiredSchema: StructType = this.requiredSchema
 
-  def copyConfig(newId: Boolean): ReadConfig = {
-    if(!newId) {
-      this.copy()
-    } else {
-      this.copy(fileStoreConfig = this.fileStoreConfig.copy(sessionId = SessionId.getId))
-    }
+  def copyConfig(): ReadConfig = {
+    this.copy(fileStoreConfig = this.fileStoreConfig.copy(sessionId = SessionId.getId))
   }
 }

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -219,13 +219,13 @@ class VerticaDistributedFilesystemReadPipe(
 
       // Create unique directory for session
       perm = config.filePermissions
-      _ = logger.debug("Creating unique directory: " + fileStoreConfig.address + " with permissions: " + perm)
+      _ = logger.info("Creating unique directory: " + fileStoreConfig.address + " with permissions: " + perm)
 
       _ <- fileStoreLayer.createDir(fileStoreConfig.address, perm.toString) match {
         case Left(err) =>
           err.getError match {
             case CreateDirectoryAlreadyExistsError(_) =>
-              logger.debug("Directory already existed: " + fileStoreConfig.address)
+              logger.info("Directory already existed: " + fileStoreConfig.address)
               Right(())
             case _ => Left(err.context("Failed to create directory: " + fileStoreConfig.address))
           }

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
@@ -44,8 +44,6 @@ class VerticaScanBuilder(config: ReadConfig, readConfigSetup: DSConfigSetupInter
   SupportsPushDownFilters with SupportsPushDownRequiredColumns {
   private var pushFilters: List[PushFilter] = Nil
 
-  private var lastPushedFilters: List[PushFilter] = Nil
-
   private var requiredSchema: StructType = StructType(Nil)
 
 /**
@@ -54,14 +52,9 @@ class VerticaScanBuilder(config: ReadConfig, readConfigSetup: DSConfigSetupInter
   * @return [[VerticaScan]]
   */
   override def build(): Scan = {
-    // This will be called twice per operation usually, so need to check if filters are different
-    val newOperation = pushFilters != lastPushedFilters
-
-    val cfg = config.copyConfig(newOperation)
+    val cfg = config.copyConfig()
     cfg.setPushdownFilters(this.pushFilters)
     cfg.setRequiredSchema(this.requiredSchema)
-
-    lastPushedFilters = pushFilters
 
     new VerticaScan(cfg, readConfigSetup)
   }

--- a/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
@@ -497,7 +497,6 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
 
     // Implementation currently based on config, not identifier
     assert(catalog.tableExists(mock[Identifier]))
-
   }
 
   it should "catalog loads table on load or create" in {

--- a/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
@@ -165,7 +165,7 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
   it should "table returns schema" in {
     val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
     (readSetup.validateAndGetConfig _).expects(options.toMap).returning(Valid(readConfig)).twice()
-    (readSetup.getTableSchema _).expects(readConfig).returning(Right(intSchema))
+    (readSetup.getTableSchema _).expects(*).returning(Right(intSchema))
 
     val table = new VerticaTable(options, readSetup)
 
@@ -488,7 +488,7 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
   it should "catalog tests if table exists" in {
     val readSetup = mock[DSConfigSetupInterface[ReadConfig]]
     (readSetup.validateAndGetConfig _).expects(options.toMap).returning(Valid(readConfig)).twice()
-    (readSetup.getTableSchema _).expects(readConfig).returning(Right(intSchema))
+    (readSetup.getTableSchema _).expects(*).returning(Right(intSchema))
 
     val catalog = new VerticaDatasourceV2Catalog()
     catalog.readSetupInterface = readSetup
@@ -497,6 +497,7 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
 
     // Implementation currently based on config, not identifier
     assert(catalog.tableExists(mock[Identifier]))
+
   }
 
   it should "catalog loads table on load or create" in {

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -213,7 +213,6 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     TestUtils.dropTable(conn, tableName1)
   }
 
-
   it should "df alias and join" in {
     val tableName1 = "dftest1"
     val stmt = conn.createStatement

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -213,6 +213,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     TestUtils.dropTable(conn, tableName1)
   }
 
+
   it should "df alias and join" in {
     val tableName1 = "dftest1"
     val stmt = conn.createStatement
@@ -243,39 +244,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     TestUtils.dropTable(conn, tableName1)
   }
 
-  it should "triple join" in {
-    val tableName1 = "dftest1"
-    val stmt = conn.createStatement
-    val n = 20
-    TestUtils.createTableBySQL(conn, tableName1, "create table " + tableName1 + " (a int, b int)")
 
-    val insert = "insert into "+ tableName1 + " values(2, 3)"
-    TestUtils.populateTableBySQL(stmt, insert, n)
-    val insert2 = "insert into "+ tableName1 + " values(3, 7)"
-    TestUtils.populateTableBySQL(stmt, insert2, n)
-
-    val df: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(readOpts + ("table" -> tableName1)).load()
-
-    println("Getting count")
-    println("Count: " + df.count())
-
-
-    println("Getting as1")
-    val df_as1 = df.as("df1")
-
-    println("Getting as2")
-    val df_as2 = df.as("df2")
-
-    println("Getting as3")
-    val df_as3 = df.as("df3")
-
-    println("Joining")
-    val joined_df = df_as1.join(
-      df_as2, col("df1.a") === col("df2.b"), "inner").join(
-        df_as3, col("df1.a") === col("df3.b"), "inner")
-    assert(joined_df.collect().length == n*n*n)
-    TestUtils.dropTable(conn, tableName1)
-  }
 
   it should "collect results" in {
     val tableName1 = "dftest1"
@@ -814,6 +783,10 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     dr.show
     stmt.execute("drop table " + tableName1)
+
+    fsLayer.removeDir(fsConfig.address)
+    // Need to recreate the root directory for the afterEach assertion check
+    fsLayer.createDir(fsConfig.address, "777")
   }
 
   it should "load data from Vertica with no column projection pushdown" in {
@@ -840,6 +813,10 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     df.show
     stmt.execute("drop table " + tableName1)
+
+    fsLayer.removeDir(fsConfig.address)
+    // Need to recreate the root directory for the afterEach assertion check
+    fsLayer.createDir(fsConfig.address, "777")
   }
 
   it should "load data from Vertica with a column projection pushdown with the correct values" in {
@@ -3731,5 +3708,34 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     TestUtils.dropTable(conn, tableName)
   }
 
+  it should "triple join" in {
+    val tableName1 = "dftest1"
+    val stmt = conn.createStatement
+    val n = 20
+    TestUtils.createTableBySQL(conn, tableName1, "create table " + tableName1 + " (a int, b int, c int)")
+
+    val insert = "insert into "+ tableName1 + " values(2, 3, 10)"
+    TestUtils.populateTableBySQL(stmt, insert, n)
+    val insert2 = "insert into "+ tableName1 + " values(3, 7, 10)"
+    TestUtils.populateTableBySQL(stmt, insert2, n)
+
+    val df: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(readOpts + ("table" -> tableName1)).load()
+
+    println("Getting as1")
+    val df_as1 = df.as("df1")
+
+    println("Getting as2")
+    val df_as2 = df.as("df2")
+
+    println("Getting as3")
+    val df_as3 = df.as("df3")
+
+    println("Joining")
+    val joined_df = df_as1.join(
+      df_as2, col("df1.a") === col("df2.b"), "inner").join(
+      df_as3, col("df1.a") === col("df3.b"), "inner")
+    assert(joined_df.collect().length == n*n*n)
+    TestUtils.dropTable(conn, tableName1)
+  }
 }
 


### PR DESCRIPTION
### Summary

Fix duplicate ID issue causing read to fail under specific circumstances.

### Description

Previously, we would copy with a unique ID unless the filters were the same. This was based on a confusion between the planInputPartitions and scan build functions. The former is called twice per operation, and it was assumed the later was as well. This is not the case, so there is no need to filter the copying, we can always copy with a new unique ID.


### Additional Reviewers

@jonathanl-bq 
@ravjotbrar 