### PR TITLE
Add configureSession to external table commit

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -369,6 +369,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
     }
 
     val ret = for {
+      _ <- jdbcLayer.configureSession(fileStoreLayer)
       _ <- tableUtils.createExternalTable(
         tablename = config.tablename,
         targetTableSql = config.targetTableSql,

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -581,13 +581,14 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val expectedUrl = config.fileStoreConfig.address + "/*.parquet"
 
+    val fileStoreLayerInterface = mock[FileStoreLayerInterface]
+
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
     (jdbcLayerInterface.close _).expects().returning(Right(()))
+    (jdbcLayerInterface.configureSession _).expects(fileStoreLayerInterface).returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-
-    val fileStoreLayerInterface = mock[FileStoreLayerInterface]
 
     val tableUtils = mock[TableUtilsInterface]
     (tableUtils.createExternalTable _).expects(tname, config.targetTableSql, config.schema, config.strlen, expectedUrl).returning(Right(()))
@@ -605,13 +606,14 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val expectedUrl = config.fileStoreConfig.address + "/*.parquet"
 
+    val fileStoreLayerInterface = mock[FileStoreLayerInterface]
+
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
     (jdbcLayerInterface.close _).expects().returning(Right(()))
+    (jdbcLayerInterface.configureSession _).expects(fileStoreLayerInterface).returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-
-    val fileStoreLayerInterface = mock[FileStoreLayerInterface]
 
     val tableUtils = mock[TableUtilsInterface]
     (tableUtils.createExternalTable _).expects(tname, config.targetTableSql, config.schema, config.strlen, expectedUrl).returning(Left(ConnectionDownError()))
@@ -631,13 +633,14 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val expectedUrl = config.fileStoreConfig.address + "/*.parquet"
 
+    val fileStoreLayerInterface = mock[FileStoreLayerInterface]
+
     val jdbcLayerInterface = mock[JdbcLayerInterface]
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
     (jdbcLayerInterface.close _).expects().returning(Right(()))
+    (jdbcLayerInterface.configureSession _).expects(fileStoreLayerInterface).returning(Right(()))
 
     val schemaToolsInterface = mock[SchemaToolsInterface]
-
-    val fileStoreLayerInterface = mock[FileStoreLayerInterface]
 
     val tableUtils = mock[TableUtilsInterface]
     (tableUtils.createExternalTable _).expects(tname, config.targetTableSql, config.schema, config.strlen, expectedUrl).returning(Right())

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -3384,19 +3384,9 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
       writeOpts + ("table" -> tableName, "create_external_table" -> "true")
     ).mode(mode).save()
 
-    val stmt = conn.createStatement()
-    val query = "SELECT * FROM " + tableName
-    try {
-      val rs = stmt.executeQuery(query)
-      assert (rs.next)
-      assert (rs.getInt(1) ==  77)
-    }
-    catch{
-      case err : Exception => fail(err)
-    }
-    finally {
-      stmt.close()
-    }
+    val readDf: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource").options(readOpts + ("table" -> tableName)).load()
+
+    assert(readDf.head() == data.head)
 
     TestUtils.dropTable(conn, tableName)
 


### PR DESCRIPTION
### Summary

The external table tests were failing in a kerberized environment and in our s3 integration tests. This update fixes that bug.

### Description

This change added jdbcLayer.configureSession(fileStoreLayer) in the commitDataAsExternalTable method.

### Related Issue

https://github.com/vertica/spark-connector/issues/189

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
