### PR TITLE
Change functional-tests jar version to 2.0.1

### DIFF
--- a/functional-tests/s3-functional-tests.sh
+++ b/functional-tests/s3-functional-tests.sh
@@ -13,4 +13,4 @@ export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
 start-master.sh
 start-slave.sh spark://localhost:7077
 cd ../../../spark-connector/functional-tests
-spark-submit --master spark://localhost:7077 target/scala-2.12/spark-vertica-connector-functional-tests-assembly-1.0.jar
+spark-submit --master spark://localhost:7077 target/scala-2.12/spark-vertica-connector-functional-tests-assembly-2.0.1.jar


### PR DESCRIPTION
### Summary

This change updates the script to run the s3-integration tests script to submit the 2.0.1 functional-tests jar instead of the 1.0.

### Description

Change functional-tests jar version to 2.0.1 from 1.0

### Related Issue

https://github.com/vertica/spark-connector/issues/204

### Additional Reviewers

@jonathanl-bq 
@alexr-bq 
