### PR TITLE
Increase active sessions in db from 55 to 100

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,12 +76,13 @@ jobs:
         run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
       - name: Replace HDFS hdfs-site config with our own
         run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
           name: build-jar-file
           path: ./functional-tests/lib/
+      - name: Increase active sessions in database
+        run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Copy functional tests to home directory of client container
         run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
       - name: Run the integration tests on Spark 3.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,15 +49,15 @@ jobs:
         run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
       - name: Replace HDFS hdfs-site config with our own
         run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-      - name: Sleep
-        run: docker exec docker_vertica_1 sleep 10
-      - name: Increase active sessions in database
-        run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
           name: build-jar-file
           path: ./functional-tests/lib/
+      - name: Sleep
+        run: docker exec docker_vertica_1 sleep 10
+      - name: Increase active sessions in database
+        run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Copy functional tests to home directory of client container
         run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
       - name: Run the integration tests on Spark 3.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,8 @@ jobs:
         run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
       - name: Replace HDFS hdfs-site config with our own
         run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+      - name: Connect to vsql
+        run: docker exec docker_vertica_1 vsql -h vertica -U dbadmin -C
       - name: Increase active sessions in database
         run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Download the build artifact
@@ -81,6 +83,8 @@ jobs:
         with:
           name: build-jar-file
           path: ./functional-tests/lib/
+      - name: Connect to vsql
+        run: docker exec docker_vertica_1 vsql -h vertica -U dbadmin -C
       - name: Increase active sessions in database
         run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Copy functional tests to home directory of client container

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,8 @@ jobs:
         run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
       - name: Replace HDFS hdfs-site config with our own
         run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-
+      - name: Increase active sessions in database
+        run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           name: build-jar-file
           path: ./functional-tests/lib/
       - name: Sleep
-        run: docker exec docker_vertica_1 sleep 10
+        run: docker exec docker_vertica_1 sleep 15
       - name: Increase active sessions in database
         run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Copy functional tests to home directory of client container
@@ -84,7 +84,7 @@ jobs:
           name: build-jar-file
           path: ./functional-tests/lib/
       - name: Sleep
-        run: docker exec docker_vertica_1 sleep 10
+        run: docker exec docker_vertica_1 sleep 15
       - name: Increase active sessions in database
         run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Copy functional tests to home directory of client container

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,8 @@ jobs:
         run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
       - name: Replace HDFS hdfs-site config with our own
         run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-      - name: Connect to vsql
-        run: docker exec docker_vertica_1 vsql -h vertica -U dbadmin -C
+      - name: Sleep
+        run: docker exec docker_vertica_1 sleep 10
       - name: Increase active sessions in database
         run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Download the build artifact
@@ -83,8 +83,8 @@ jobs:
         with:
           name: build-jar-file
           path: ./functional-tests/lib/
-      - name: Connect to vsql
-        run: docker exec docker_vertica_1 vsql -h vertica -U dbadmin -C
+      - name: Sleep
+        run: docker exec docker_vertica_1 sleep 10
       - name: Increase active sessions in database
         run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Copy functional tests to home directory of client container

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -43,6 +43,8 @@ jobs:
         run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
       - name: Replace HDFS hdfs-site config with our own
         run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+      - name: Increase active sessions in database
+        run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Run the integration tests
         run: docker exec -w /spark-connector/functional-tests docker_client_1 /bin/bash -c "export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID; export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY; export hadoopVersion=$HADOOP_VERSION; sparkVersion=$SPARK_VERSION; ./s3-functional-tests.sh"
         env:

--- a/docker/sandbox-clientenv.sh
+++ b/docker/sandbox-clientenv.sh
@@ -3,4 +3,5 @@ docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/c
 docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
 docker exec docker_hdfs_1 /opt/hadoop/sbin/stop-dfs.sh
 docker exec docker_hdfs_1 /opt/hadoop/sbin/start-dfs.sh
+docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
 docker exec -it docker_client_1 /bin/bash


### PR DESCRIPTION
### Summary

This change adds a docker exec command to the Vertica container which alters the MaxClientSessions in our database from 55 to 100. 

### Description

The docker exec command was added to both workflows that run our integration tests. 

### Related Issue

https://github.com/vertica/spark-connector/issues/203

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
