### PR TITLE
Change version of connector jar from maven central

### DIFF
--- a/examples/basic-read-example/build.sbt
+++ b/examples/basic-read-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/basic-write-example/build.sbt
+++ b/examples/basic-write-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/demo/build.sbt
+++ b/examples/demo/build.sbt
@@ -21,5 +21,5 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
 )

--- a/examples/kerberos-example/build.sbt
+++ b/examples/kerberos-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/merge-example/build.sbt
+++ b/examples/merge-example/build.sbt
@@ -23,6 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/merge-example2/build.sbt
+++ b/examples/merge-example2/build.sbt
@@ -23,6 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/s3-example/build.sbt
+++ b/examples/s3-example/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
   "org.apache.hadoop" % "hadoop-aws" % "3.3.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.0-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
 )
 
 assembly / assemblyMergeStrategy := {


### PR DESCRIPTION
### Summary

Change connector jar version in examples' dependencies. 

### Description

Changed jar version from "com.vertica.spark" % "vertica-spark" % "2.0.0-0" to "com.vertica.spark" % "vertica-spark" % "2.0.1-0"

### Related Issue
https://github.com/vertica/spark-connector/issues/208

### Additional Reviewers
@jonathanl-bq 
@alexr-bq 
