### PR TITLE
Add sleep to s3-integration workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,10 +54,12 @@ jobs:
         with:
           name: build-jar-file
           path: ./functional-tests/lib/
-      - name: Sleep
-        run: docker exec docker_vertica_1 sleep 15
       - name: Increase active sessions in database
-        run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 15
+          retry_on: error
+          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Copy functional tests to home directory of client container
         run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
       - name: Run the integration tests on Spark 3.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,8 +89,13 @@ jobs:
       - name: Sleep
         run: docker exec docker_vertica_1 sleep 15
       - name: Increase active sessions in database
-        run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
-      - name: Copy functional tests to home directory of client container
+      - name: Increase active sessions in database
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"      - name: Copy functional tests to home directory of client container
         run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
       - name: Run the integration tests on Spark 3.1
         run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="3.1.1" -DhadoopVersion="3.3.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,8 @@ jobs:
           timeout_seconds: 20
           max_attempts: 10
           retry_on: error
-          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"      - name: Copy functional tests to home directory of client container
+          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+      - name: Copy functional tests to home directory of client container
         run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
       - name: Run the integration tests on Spark 3.1
         run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="3.1.1" -DhadoopVersion="3.3.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           timeout_seconds: 20
-          max_attempts: 15
+          max_attempts: 10
           retry_on: error
           command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Copy functional tests to home directory of client container
@@ -86,9 +86,6 @@ jobs:
         with:
           name: build-jar-file
           path: ./functional-tests/lib/
-      - name: Sleep
-        run: docker exec docker_vertica_1 sleep 15
-      - name: Increase active sessions in database
       - name: Increase active sessions in database
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Increase active sessions in database
         uses: nick-invision/retry@v2
         with:
+          timeout_seconds: 20
           max_attempts: 15
           retry_on: error
           command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -47,7 +47,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           timeout_seconds: 20
-          max_attempts: 15
+          max_attempts: 10
           retry_on: error
           command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Run the integration tests

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -43,10 +43,12 @@ jobs:
         run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
       - name: Replace HDFS hdfs-site config with our own
         run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-      - name: Sleep
-        run: docker exec docker_vertica_1 sleep 15
       - name: Increase active sessions in database
-        run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 15
+          retry_on: error
+          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Run the integration tests
         run: docker exec -w /spark-connector/functional-tests docker_client_1 /bin/bash -c "export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID; export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY; export hadoopVersion=$HADOOP_VERSION; sparkVersion=$SPARK_VERSION; ./s3-functional-tests.sh"
         env:

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Increase active sessions in database
         uses: nick-invision/retry@v2
         with:
+          timeout_seconds: 20
           max_attempts: 15
           retry_on: error
           command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -43,6 +43,8 @@ jobs:
         run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
       - name: Replace HDFS hdfs-site config with our own
         run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+      - name: Sleep
+        run: docker exec docker_vertica_1 sleep 15
       - name: Increase active sessions in database
         run: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
       - name: Run the integration tests


### PR DESCRIPTION
### Summary

Add sleep before increasing active sessions in s3 workflow

### Description

Added a docker exec command to sleep for 15 seconds so the container has time to connect to vsql

### Related Issue

https://github.com/vertica/spark-connector/issues/211

### Additional Reviewers

@jonathanl-bq 
@alexr-bq 
