### PR TITLE
Refactor run-example script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,13 @@ RUN yum install -y java-11-openjdk && \
     yum update -y && yum install -y wget && \
     curl -L https://www.scala-sbt.org/sbt-rpm.repo > sbt-rpm.repo && \
     mv sbt-rpm.repo /etc/yum.repos.d/ && \
-    yum -y install sbt
+    yum -y install sbt && \
+    wget https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz && \
+    wget https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz && \
+    tar xvf spark-3.1.2-bin-without-hadoop.tgz && \
+    tar xvf hadoop-3.3.0.tar.gz && \
+    mv spark-3.1.2-bin-without-hadoop/ /opt/spark && \
+    cd /opt/spark/conf && \
+    mv spark-env.sh.template spark-env.sh
 
 ENTRYPOINT ["/bin/bash"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # How to run the examples
 
-**Note**: The instructions for running the S3, Kerberos, and PySpark example are different. If you would like to run those examples, please see their respective READMEs. 
+**Note**: The instructions for running the S3, Kerberos, Sparklyr, and PySpark example are different. If you would like to run those examples, please see their respective READMEs.
 
 Make sure you have docker and sbt installed.
 Tested using docker 20.10.0, sbt 1.4.1
@@ -74,16 +74,11 @@ Now change your working directory to the examples directory `spark-connector/exa
 
 Once in the examples directory, run:
 ```
-./run-example.sh [REPLACE WITH EXAMPLE DIR]/target/scala-2.12/spark-vertica-connector-[REPLACE WITH EXAMPLE DIR]-assembly-2.0.jar
+./run-example.sh [REPLACE WITH EXAMPLE DIR]/target/scala-2.12/spark-vertica-connector-[REPLACE WITH EXAMPLE DIR]-assembly-2.0.1.jar
 ``` 
 Example argument: basic-read-example/target/scala-2.12/spark-vertica-connector-basic-read-example-assembly-2.0.1.jar
 
-Running this script for the first time will install Spark and user-provided Hadoop. This may take some time; however, running the script subsequently will forgo those steps. If you would like to include those steps then add a 'clean' argument to the script:
-```
-./run-example.sh clean [REPLACE WITH EXAMPLE DIR]/target/scala-2.12/spark-vertica-connector-[REPLACE WITH EXAMPLE DIR]-assembly-2.0.jar
-``` 
-
-There are additional prerequisites to run the S3, Pyspark, or Kerberos examples. If you want to run these, please take a look at their respective README files. 
+There are additional prerequisites to run the S3, Pyspark, Sparklyr, or Kerberos examples. If you want to run these, please take a look at their respective README files.
 
 
 

--- a/examples/merge-example/build.sbt
+++ b/examples/merge-example/build.sbt
@@ -23,6 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/merge-example2/build.sbt
+++ b/examples/merge-example2/build.sbt
@@ -23,6 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/pyspark/run-python-example.sh
+++ b/examples/pyspark/run-python-example.sh
@@ -1,48 +1,12 @@
-if [ "$1" == "clean" ]
-  then
-    yum install -y python3
-    wget -P ../../ https://archive.apache.org/dist/spark/spark-3.0.3/spark-3.0.3-bin-without-hadoop.tgz
-    wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
-    cd ../../
-    tar xvf spark-3.0.2-bin-without-hadoop.tgz
-    tar xvf hadoop-3.3.0.tar.gz
-    mv spark-3.0.2-bin-without-hadoop/ /opt/spark
-    cd /opt/spark/conf
-    mv spark-env.sh.template spark-env.sh
-    export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
-    export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
-    export SPARK_HOME=/opt/spark
-    export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
-    start-master.sh
-    start-slave.sh spark://localhost:7077
-    cd ../../../spark-connector/examples
-    spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.1.jar sparkapp.py
+yum install -y python3
+export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
+export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
+export SPARK_HOME=/opt/spark
+export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
+start-master.sh
+start-worker.sh spark://localhost:7077
+spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.1.jar sparkapp.py
 
-elif [ -a ../../hadoop-3.3.0 ]
-  then
-    export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
-    export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
-    export SPARK_HOME=/opt/spark
-    export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
-    spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.1.jar sparkapp.py
 
-else
-  yum install -y python3
-  wget -P ../../ https://archive.apache.org/dist/spark/spark-3.0.3/spark-3.0.3-bin-without-hadoop.tgz
-  wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
-  cd ../../
-  tar xvf spark-3.0.2-bin-without-hadoop.tgz
-  tar xvf hadoop-3.3.0.tar.gz
-  mv spark-3.0.2-bin-without-hadoop/ /opt/spark
-  cd /opt/spark/conf
-  mv spark-env.sh.template spark-env.sh
-  export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
-  export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
-  export SPARK_HOME=/opt/spark
-  export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
-  start-master.sh
-  start-slave.sh spark://localhost:7077
-  cd ../../../spark-connector/examples
-  spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.1.jar sparkapp.py
 
-fi
+

--- a/examples/run-example.sh
+++ b/examples/run-example.sh
@@ -1,46 +1,8 @@
-if [ "$1" == "clean" ]
-  then
-    wget -P ../../ https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
-    wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
-    cd ../../
-    tar xvf spark-3.1.2-bin-without-hadoop.tgz
-    tar xvf hadoop-3.3.0.tar.gz
-    mv spark-3.1.2-bin-without-hadoop/ /opt/spark
-    cd /opt/spark/conf
-    mv spark-env.sh.template spark-env.sh
-    export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
-    export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
-    export SPARK_HOME=/opt/spark
-    export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
-    start-master.sh
-    start-slave.sh spark://localhost:7077
-    cd ../../../spark-connector/examples
-    spark-submit --master spark://localhost:7077 $2
+export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
+export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
+export SPARK_HOME=/opt/spark
+export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
+start-master.sh
+start-worker.sh spark://localhost:7077
+spark-submit --master spark://localhost:7077 $1
 
-elif [ -a ../../hadoop-3.3.0 ]
-  then
-    export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
-    export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
-    export SPARK_HOME=/opt/spark
-    export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
-    spark-submit --master spark://localhost:7077 $1
-
-else
-  wget -P ../../ https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
-  wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
-  cd ../../
-  tar xvf spark-3.1.2-bin-without-hadoop.tgz
-  tar xvf hadoop-3.3.0.tar.gz
-  mv spark-3.1.2-bin-without-hadoop/ /opt/spark
-  cd /opt/spark/conf
-  mv spark-env.sh.template spark-env.sh
-  export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
-  export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
-  export SPARK_HOME=/opt/spark
-  export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
-  start-master.sh
-  start-slave.sh spark://localhost:7077
-  cd ../../../spark-connector/examples
-  spark-submit --master spark://localhost:7077 $1
-
-fi

--- a/examples/sparklyr/run-r-example.sh
+++ b/examples/sparklyr/run-r-example.sh
@@ -1,56 +1,12 @@
-if [ "$1" == "clean" ]
-  then
-    yum install -y epel-release
-    yum install -y R
-    yum install -y openssl-devel
-    yum install -y libxml2-devel
-    yum install -y libcurl-devel
-    wget -P ../../../ https://mirror.dsrg.utoronto.ca/apache/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
-    wget -P ../../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
-    cd ../../../
-    tar xvf spark-3.1.2-bin-without-hadoop.tgz
-    tar xvf hadoop-3.3.0.tar.gz
-    mv spark-3.1.2-bin-without-hadoop/ /opt/spark
-    cd /opt/spark/conf
-    mv spark-env.sh.template spark-env.sh
-    export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
-    export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
-    export SPARK_HOME=/opt/spark
-    export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
-    start-master.sh
-    start-slave.sh spark://localhost:7077
-    cd /spark-connector/examples/sparklyr
-    Rscript run.r
-
-elif [ -a ../../../hadoop-3.3.0 ]
-  then
-    export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
-    export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
-    export SPARK_HOME=/opt/spark
-    export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
-    Rscript run.r
-
-else
-  yum install -y epel-release
-  yum install -y R
-  yum install -y openssl-devel
-  yum install -y libxml2-devel
-  yum install -y libcurl-devel
-  wget -P ../../../ https://mirror.dsrg.utoronto.ca/apache/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz
-  wget -P ../../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
-  cd ../../../
-  tar xvf spark-3.1.2-bin-without-hadoop.tgz
-  tar xvf hadoop-3.3.0.tar.gz
-  mv spark-3.1.2-bin-without-hadoop/ /opt/spark
-  cd /opt/spark/conf
-  mv spark-env.sh.template spark-env.sh
-  export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
-  export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
-  export SPARK_HOME=/opt/spark
-  export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
-  start-master.sh
-  start-slave.sh spark://localhost:7077
-  cd /spark-connector/examples/sparklyr
-  Rscript run.r
-
-fi
+yum install -y epel-release
+yum install -y R
+yum install -y openssl-devel
+yum install -y libxml2-devel
+yum install -y libcurl-devel
+export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
+export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
+export SPARK_HOME=/opt/spark
+export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
+start-master.sh
+start-slave.sh spark://localhost:7077
+Rscript run.r


### PR DESCRIPTION
### Summary

This change extracts out common code from different example scripts into the Dockerfile. 

### Description

Moved the download of Spark/Hadoop into the Dockerfile. This minimizes redundancy and ensures new examples that require their own scripts do not have to tweak the entire run-example script. This change also ensures that Spark and Hadoop are only downloaded when the docker containers are composed up for the first time.

### Related Issue

https://github.com/vertica/spark-connector/issues/154

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
