### PR TITLE
Update connector version to 2.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: build-jar-file
-          path: /home/runner/work/spark-connector/spark-connector/connector/target/scala-2.12/spark-vertica-connector_2.12-2.0.1.jar
+          path: /home/runner/work/spark-connector/spark-connector/connector/target/scala-2.12/spark-vertica-connector_2.12-2.0.2.jar
   run-analysis:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: build-jar-file
-          path: /home/runner/work/spark-connector/spark-connector/connector/target/scala-2.12/spark-vertica-connector_2.12-2.0.1.jar
+          path: /home/runner/work/spark-connector/spark-connector/connector/target/scala-2.12/spark-vertica-connector_2.12-2.0.2.jar
   run-integration-tests_s3:
     runs-on: ubuntu-latest
     needs: build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ cd connector
 sbt assembly
 ```
 
-Running this will run all unit tests and build the jar to target/[SCALA_VERSION]/spark-vertica-connector-assembly-2.0.1.jar
+Running this will run all unit tests and build the jar to target/[SCALA_VERSION]/spark-vertica-connector-assembly-2.0.2.jar
 
 ## Step 4: Set up an environment
 The easiest way to set up an environment is to spin up the docker containers for a sandbox client environment and single-node clusters for both Vertica and HDFS following [this guide.](https://github.com/vertica/spark-connector/blob/main/examples/README.md)
@@ -88,7 +88,7 @@ The next requirement is a spark application that uses the connector jar. Example
 ```shell
 cd examples/basic-read
 mkdir lib
-cp ../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.1.jar lib
+cp ../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.2.jar lib
 sbt run
 ```
 

--- a/connector/build.sbt
+++ b/connector/build.sbt
@@ -14,7 +14,7 @@
 scalaVersion := "2.12.12"
 name := "spark-vertica-connector"
 organization := "com.vertica"
-version := "2.0.1"
+version := "2.0.2"
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,7 +76,7 @@ Once in the examples directory, run:
 ```
 ./run-example.sh [REPLACE WITH EXAMPLE DIR]/target/scala-2.12/spark-vertica-connector-[REPLACE WITH EXAMPLE DIR]-assembly-2.0.1.jar
 ``` 
-Example argument: basic-read-example/target/scala-2.12/spark-vertica-connector-basic-read-example-assembly-2.0.1.jar
+Example argument: basic-read-example/target/scala-2.12/spark-vertica-connector-basic-read-example-assembly-2.0.2.jar
 
 ### Using Thin Jar
 If you are using the thin jar and running into an error similar to the following:

--- a/examples/basic-read-example/build.sbt
+++ b/examples/basic-read-example/build.sbt
@@ -14,7 +14,7 @@
 scalaVersion := "2.12.12"
 name := "spark-vertica-connector-basic-read-example"
 organization := "com.vertica"
-version := "2.0.1"
+version := "2.0.2"
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/basic-read-example/build.sbt
+++ b/examples/basic-read-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-slim"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/basic-read-example/build.sbt
+++ b/examples/basic-read-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/basic-write-example/build.sbt
+++ b/examples/basic-write-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-slim"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/basic-write-example/build.sbt
+++ b/examples/basic-write-example/build.sbt
@@ -14,7 +14,7 @@
 scalaVersion := "2.12.12"
 name := "spark-vertica-connector-basic-write-example"
 organization := "com.vertica"
-version := "2.0.1"
+version := "2.0.2"
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/basic-write-example/build.sbt
+++ b/examples/basic-write-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/demo/build.sbt
+++ b/examples/demo/build.sbt
@@ -21,5 +21,5 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-slim"
 )

--- a/examples/demo/build.sbt
+++ b/examples/demo/build.sbt
@@ -21,5 +21,5 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
 )

--- a/examples/demo/build.sbt
+++ b/examples/demo/build.sbt
@@ -14,12 +14,12 @@
 scalaVersion := "2.12.12"
 name := "spark-vertica-connector-demo-example"
 organization := "com.vertica"
-version := "2.0.1"
+version := "2.0.2"
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
 )

--- a/examples/kerberos-example/build.sbt
+++ b/examples/kerberos-example/build.sbt
@@ -14,7 +14,7 @@
 scalaVersion := "2.12.12"
 name := "spark-vertica-connector-kerberos-example"
 organization := "com.vertica"
-version := "2.0.1"
+version := "2.0.2"
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/kerberos-example/build.sbt
+++ b/examples/kerberos-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-slim"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/kerberos-example/build.sbt
+++ b/examples/kerberos-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/merge-example/build.sbt
+++ b/examples/merge-example/build.sbt
@@ -14,7 +14,7 @@
 scalaVersion := "2.12.12"
 name := "spark-vertica-connector-merge-example"
 organization := "com.vertica"
-version := "2.0.1"
+version := "2.0.2"
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/merge-example/build.sbt
+++ b/examples/merge-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-slim"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/merge-example/build.sbt
+++ b/examples/merge-example/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/merge-example2/build.sbt
+++ b/examples/merge-example2/build.sbt
@@ -14,7 +14,7 @@
 scalaVersion := "2.12.12"
 name := "spark-vertica-connector-merge-example2"
 organization := "com.vertica"
-version := "2.0.1"
+version := "2.0.2"
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/merge-example2/build.sbt
+++ b/examples/merge-example2/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-slim"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/merge-example2/build.sbt
+++ b/examples/merge-example2/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/pyspark/run-python-example.sh
+++ b/examples/pyspark/run-python-example.sh
@@ -5,7 +5,7 @@ export SPARK_HOME=/opt/spark
 export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
 start-master.sh
 start-worker.sh spark://localhost:7077
-spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.1.jar sparkapp.py
+spark-submit --jars ../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.2.jar sparkapp.py
 
 
 

--- a/examples/s3-example/build.sbt
+++ b/examples/s3-example/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
   "org.apache.hadoop" % "hadoop-aws" % "3.3.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/s3-example/build.sbt
+++ b/examples/s3-example/build.sbt
@@ -14,7 +14,7 @@
 scalaVersion := "2.12.12"
 name := "spark-vertica-connector-s3-example"
 organization := "com.vertica"
-version := "2.0.1"
+version := "2.0.2"
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
   "org.apache.hadoop" % "hadoop-aws" % "3.3.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.1-0"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-0"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/s3-example/build.sbt
+++ b/examples/s3-example/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "3.0.0",
   "org.apache.spark" %% "spark-sql" % "3.0.0",
   "org.apache.hadoop" % "hadoop-aws" % "3.3.0",
-  "com.vertica.spark" % "vertica-spark" % "2.0.2-all"
+  "com.vertica.spark" % "vertica-spark" % "2.0.2-slim"
 )
 
 assembly / assemblyMergeStrategy := {

--- a/examples/sparklyr/run.r
+++ b/examples/sparklyr/run.r
@@ -6,7 +6,7 @@ if (file.exists("done")) unlink("done")
 
 # Create the Spark config and give access to our connector jar file
 config <- spark_config()
-config$sparklyr.jars.default <- "../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.1.jar"
+config$sparklyr.jars.default <- "../../connector/target/scala-2.12/spark-vertica-connector-assembly-2.0.2.jar"
 
 # Submit a new Spark job that executes sparkapp.r with Spark version 3.1
 spark_submit(master = "spark://localhost:7077", version = "3.1", file = "sparkapp.r", config = config)

--- a/functional-tests/README.md
+++ b/functional-tests/README.md
@@ -8,7 +8,7 @@ Configuration is specified with application.conf (HOCON format)
 From the functional-tests directory, run the following commands:
 ```
 mkdir lib
-cd ../connector && sbt assembly && cp target/scala-2.12/spark-vertica-connector-assembly-2.0.1.jar ../functional-tests/lib && cd ../functional-tests
+cd ../connector && sbt assembly && cp target/scala-2.12/spark-vertica-connector-assembly-2.0.2.jar ../functional-tests/lib && cd ../functional-tests
 ```
 This will create a lib folder and then build and copy the connector JAR file to it.
 

--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -14,7 +14,7 @@
 scalaVersion := "2.12.12"
 name := "spark-vertica-connector-functional-tests"
 organization := "com.vertica"
-version := "2.0.1"
+version := "2.0.2"
 
 val sparkVersion = Option(System.getProperty("sparkVersion")).getOrElse("3.0.0")
 val hadoopVersion = Option(System.getProperty("hadoopVersion")).getOrElse("2.4.0")

--- a/functional-tests/s3-functional-tests.sh
+++ b/functional-tests/s3-functional-tests.sh
@@ -13,4 +13,4 @@ export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
 start-master.sh
 start-slave.sh spark://localhost:7077
 cd ../../../spark-connector/functional-tests
-spark-submit --master spark://localhost:7077 target/scala-2.12/spark-vertica-connector-functional-tests-assembly-2.0.1.jar
+spark-submit --master spark://localhost:7077 target/scala-2.12/spark-vertica-connector-functional-tests-assembly-2.0.2.jar


### PR DESCRIPTION
### Summary

Update connector version to 2.0.2 to reflect our new release

### Description

Replaced 2.0.1 with 2.0.2 in our project

### Related Issue

https://github.com/vertica/spark-connector/issues/225

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
