### PR TITLE
Simplify param passed into run-example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -74,9 +74,9 @@ Now change your working directory to the examples directory `spark-connector/exa
 
 Once in the examples directory, run:
 ```
-./run-example.sh [REPLACE WITH EXAMPLE DIR]/target/scala-2.12/spark-vertica-connector-[REPLACE WITH EXAMPLE DIR]-assembly-2.0.1.jar
+./run-example.sh [REPLACE WITH EXAMPLE DIR]
 ``` 
-Example argument: basic-read-example/target/scala-2.12/spark-vertica-connector-basic-read-example-assembly-2.0.2.jar
+Example argument: basic-read-example
 
 ### Using Thin Jar
 If you are using the thin jar and running into an error similar to the following:

--- a/examples/kerberos-example/README.md
+++ b/examples/kerberos-example/README.md
@@ -18,7 +18,7 @@ cd /spark-connector/examples/kerberos-example
 
 Run the example:
 ```
-./run-example.sh ./target/scala-2.12/spark-vertica-connector-kerberos-example-assembly-2.0.1.jar
+./run-example.sh kerberos-example
 ``` 
 
 # Rebuilding the images

--- a/examples/kerberos-example/README.md
+++ b/examples/kerberos-example/README.md
@@ -18,7 +18,7 @@ cd /spark-connector/examples/kerberos-example
 
 Run the example:
 ```
-./run-example.sh kerberos-example
+./run-kerberos-example.sh 
 ``` 
 
 # Rebuilding the images

--- a/examples/kerberos-example/run-example.sh
+++ b/examples/kerberos-example/run-example.sh
@@ -4,4 +4,4 @@ export SPARK_HOME=/opt/spark
 export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
 start-master.sh
 start-worker.sh spark://localhost:7077
-spark-submit --master spark://localhost:7077 --driver-java-options '-Djava.security.auth.login.config=/spark-connector/docker/client-krb/jaas.config' $1
+spark-submit --master spark://localhost:7077 --driver-java-options '-Djava.security.auth.login.config=/spark-connector/docker/client-krb/jaas.config' ./target/scala-2.12/spark-vertica-connector-$1-assembly-2.0.2.jar

--- a/examples/kerberos-example/run-kerberos-example.sh
+++ b/examples/kerberos-example/run-kerberos-example.sh
@@ -4,4 +4,4 @@ export SPARK_HOME=/opt/spark
 export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
 start-master.sh
 start-worker.sh spark://localhost:7077
-spark-submit --master spark://localhost:7077 --driver-java-options '-Djava.security.auth.login.config=/spark-connector/docker/client-krb/jaas.config' ./target/scala-2.12/spark-vertica-connector-$1-assembly-2.0.2.jar
+spark-submit --master spark://localhost:7077 --driver-java-options '-Djava.security.auth.login.config=/spark-connector/docker/client-krb/jaas.config' ./target/scala-2.12/spark-vertica-connector-kerberos-example-assembly-2.0.2.jar

--- a/examples/run-example.sh
+++ b/examples/run-example.sh
@@ -4,5 +4,5 @@ export SPARK_HOME=/opt/spark
 export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
 start-master.sh
 start-worker.sh spark://localhost:7077
-spark-submit --master spark://localhost:7077 $1
+spark-submit --master spark://localhost:7077 $1/target/scala-2.12/spark-vertica-connector-$1-assembly-2.0.2.jar
 


### PR DESCRIPTION
### Summary

Before this change, we needed to pass the entire path to the assembled jar file of the example we want to run. Now, we only need to pass in the example's name as a parameter.

### Description

Same as above. Changes made in run-example.sh and readme. 

### Related Issue

https://github.com/vertica/spark-connector/issues/236

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
@valentina-bq 