### PR TITLE
Fixed kerberos environment setup on Windows.

### DIFF
--- a/docker/sandbox-clientenv.bat
+++ b/docker/sandbox-clientenv.bat
@@ -1,23 +1,7 @@
 @echo off
 
 IF "%~1" == "kerberos" (
-	echo "running kerberos docker compose"
-	docker compose -f docker-compose-kerberos.yml up -d
-	echo "configuring kdc"
-	docker exec kdc /kdc/configure.sh
-	echo "configuring hdfs"
-	docker exec hdfs service ssh start
-	docker exec hdfs start-dfs.sh
-	docker exec -u 0 hdfs /hdfs-krb/kerberize.sh
-	docker exec hdfs stop-dfs.sh
-	docker exec hdfs start-dfs.sh
-	echo "configuring client"
-	docker exec docker_krbclient_1 /client-krb/kerberize.sh
-	docker exec vertica /bin/sh -c "echo %undefined% hdfs.example.com hdfs | sudo tee -a /etc/hosts"
-	docker exec docker_krbclient_1 /bin/sh -c "echo %undefined% hdfs.example.com hdfs | tee -a /etc/hosts"
-	echo "configuring db"
-	docker exec -u 0 vertica /vertica-krb/kerberize.sh
-	docker exec -it docker_krbclient_1 /bin/bash
+	call sandbox-kerberos-clientenv.bat
 ) ELSE (
 	echo "running non-kerberized docker compose"
 	docker compose -f docker-compose.yml up -d

--- a/docker/sandbox-kerberos-clientenv.bat
+++ b/docker/sandbox-kerberos-clientenv.bat
@@ -1,0 +1,22 @@
+@echo off
+
+echo "running kerberos docker compose"
+docker compose -f docker-compose-kerberos.yml up -d
+echo "configuring kdc"
+docker exec kdc /kdc/configure.sh
+echo "configuring hdfs"
+docker exec hdfs service ssh start
+docker exec hdfs start-dfs.sh
+docker exec -u 0 hdfs /hdfs-krb/kerberize.sh
+docker exec hdfs stop-dfs.sh
+docker exec hdfs start-dfs.sh
+echo "configuring client"
+docker exec docker_krbclient_1 /client-krb/kerberize.sh
+FOR /F "tokens=* USEBACKQ" %%F IN (`docker inspect -f "{{with index .NetworkSettings.Networks \"EXAMPLE.COM\"}}{{.IPAddress}}{{end}}" hdfs`) DO (
+	SET ip_address_var=%%F
+)
+docker exec vertica /bin/sh -c "echo %ip_address_var% hdfs.example.com hdfs | sudo tee -a /etc/hosts"
+docker exec docker_krbclient_1 /bin/sh -c "echo %ip_address_var% hdfs.example.com hdfs | tee -a /etc/hosts"
+echo "configuring db"
+docker exec -u 0 vertica /vertica-krb/kerberize.sh
+docker exec -it docker_krbclient_1 /bin/bash


### PR DESCRIPTION
### Summary
Fixed kerberos environment setup on Windows.
<!--- General summary / title -->

### Description
Moved kerberos environment setup into the separate script named `sandbox-kerberos-clientenv.bat`, which is called indirectly from the main `sandbox-clientenv.bat` when `kerberos` parameter is provided. This way user experience doesn't change, although running the new script directly would work the same.
<!--- Details of what you changed -->

### Related Issue
https://github.com/vertica/spark-connector/issues/242
<!--- Link to issue where this is tracked -->

### Additional Reviewers
@jonathanl-bq 
@alexey-temnikov 
@alexr-bq 
@ravjotbrar 
<!-- Any additional reviewers -->
