### PR TITLE
Ensure external table tests work with s3

### DIFF
--- a/functional-tests/s3-functional-tests.sh
+++ b/functional-tests/s3-functional-tests.sh
@@ -1,16 +1,7 @@
-wget -P ../../ https://archive.apache.org/dist/spark/spark-3.0.3/spark-3.0.3-bin-without-hadoop.tgz
-wget -P ../../ https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz
-cd ../../
-tar xvf spark-3.0.3-bin-without-hadoop.tgz
-tar xvf hadoop-3.3.0.tar.gz
-mv spark-3.0.3-bin-without-hadoop/ /opt/spark
-cd /opt/spark/conf
-mv spark-env.sh.template spark-env.sh
 export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk
 export SPARK_DIST_CLASSPATH=$(/hadoop-3.3.0/bin/hadoop classpath)
 export SPARK_HOME=/opt/spark
 export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
 start-master.sh
 start-slave.sh spark://localhost:7077
-cd ../../../spark-connector/functional-tests
 spark-submit --master spark://localhost:7077 target/scala-2.12/spark-vertica-connector-functional-tests-assembly-2.0.3.jar

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/EndToEndTests.scala
@@ -3524,7 +3524,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
   it should "create an external table with existing data in FS" in {
     // Write data to parquet
     val tableName = "existingData"
-    val filePath = "webhdfs://hdfs:50070/data/existingData.parquet"
+    val filePath = fsConfig.address + "existingData"
     val schema = new StructType(Array(StructField("col1", IntegerType)))
     val data = (1 to 20).map(x => Row(x))
     val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
@@ -3539,13 +3539,13 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     TestUtils.dropTable(conn, tableName)
     // Extra cleanup for external table
-    fsLayer.removeDir("webhdfs://hdfs:50070/data/")
-    fsLayer.createDir("webhdfs://hdfs:50070/data/", "777")
+    fsLayer.removeDir(fsConfig.address)
+    fsLayer.createDir(fsConfig.address, "777")
   }
 
   it should "create an external table with existing data in FS and multiple data types" in {
     val tableName = "existingData"
-    val filePath = "webhdfs://hdfs:50070/data/existingData.parquet"
+    val filePath = fsConfig.address + "existingData.parquet/"
     val schema = new StructType(Array(
       StructField("col1", StringType),
       StructField("col2", DateType),
@@ -3571,13 +3571,13 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     TestUtils.dropTable(conn, tableName)
     // Extra cleanup for external table
-    fsLayer.removeDir("webhdfs://hdfs:50070/data/")
-    fsLayer.createDir("webhdfs://hdfs:50070/data/", "777")
+    fsLayer.removeDir(fsConfig.address)
+    fsLayer.createDir(fsConfig.address, "777")
   }
 
   it should "create an external table with existing data and non-empty schema" in {
     val tableName = "existingData"
-    val filePath = "webhdfs://hdfs:50070/data/existingData.parquet"
+    val filePath = fsConfig.address + "existingData"
     val schema = new StructType(Array(StructField("col1", IntegerType)))
     val data = (1 to 20).map(x => Row(x))
     val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
@@ -3592,19 +3592,15 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     TestUtils.dropTable(conn, tableName)
     // Extra cleanup for external table
-    fsLayer.removeDir("webhdfs://hdfs:50070/data/")
-    fsLayer.createDir("webhdfs://hdfs:50070/data/", "777")
+    fsLayer.removeDir(fsConfig.address)
+    fsLayer.createDir(fsConfig.address, "777")
   }
 
   it should "use provided schema when creating an external table with partition columns" in {
     // Write data to parquet
     val tableName = "existingData"
-    val filePath = "webhdfs://hdfs:50070/data/existingData.parquet"
-    val schema = new StructType(Array(StructField("col1", IntegerType), StructField("col2", FloatType)))
-    val data = (1 to 20).map(x => Row(x, x.toFloat))
-    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
-    df.write.partitionBy("col1").format("parquet").save("webhdfs://hdfs:50070/data/existingData.parquet")
-
+    val filePath = "webhdfs://hdfs:50070/3.1.1/"
+    val schema = new StructType(Array(StructField("col1", IntegerType)))
     val df2 = spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
     val mode = SaveMode.Overwrite
     df2.write.format("com.vertica.spark.datasource.VerticaSource").options(writeOpts + ("staging_fs_url" -> filePath, "table" -> tableName, "create_external_table" -> "existing-data")).mode(mode).save()
@@ -3614,8 +3610,8 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
     TestUtils.dropTable(conn, tableName)
     // Extra cleanup for external table
-    fsLayer.removeDir("webhdfs://hdfs:50070/data/")
-    fsLayer.createDir("webhdfs://hdfs:50070/data/", "777")
+    fsLayer.removeDir(fsConfig.address)
+    fsLayer.createDir(fsConfig.address, "777")
   }
 
   it should "fail to create external table if partial schema does not match partition columns" in {
@@ -3665,7 +3661,7 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
 
    it should "fail to create an external table with existing data and non-empty DF" in {
     val tableName = "existingData"
-    val filePath = "webhdfs://hdfs:50070/data/existingData.parquet"
+    val filePath = fsConfig.address + "existingData"
     val schema = new StructType(Array(StructField("col1", IntegerType)))
     val data = (1 to 20).map(x => Row(x))
     val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
@@ -3695,8 +3691,8 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
       }
       TestUtils.dropTable(conn, tableName)
       // Extra cleanup for external table
-      fsLayer.removeDir("webhdfs://hdfs:50070/data/")
-      fsLayer.createDir("webhdfs://hdfs:50070/data/", "777")
+      fsLayer.removeDir(fsConfig.address)
+      fsLayer.createDir(fsConfig.address, "777")
     }
 
   }


### PR DESCRIPTION
### Summary

Made some changes to external table tests' filepath to ensure they work with s3. 

### Description

Fixed the s3 script so it doesn't download hadoop and spark again. Also made sure external table tests are using fsConfig.address instead of hardcoding hdfs filepath. 

### Related Issue

https://github.com/vertica/spark-connector/issues/254

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
@valentina-bq 
