### PR TITLE
Accommodate hdfs high-availability configuration

### DIFF
--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -41,8 +41,6 @@ jobs:
         run: cd docker && docker-compose up -d
       - name: Create db in Vertica
         run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
-      - name: Un-detatch sshd in Vertica
-        run: docker exec docker_vertica_1 /bin/sh -c "sudo /usr/sbin/sshd -D"
       - name: Replace HDFS core-site config with our own
         run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
       - name: Replace HDFS hdfs-site config with our own


### PR DESCRIPTION
### Summary

Prior to this change, when getting the delegation token, the connector only checked for a single namenode address. When the user has a high-availability setup we needed to ensure that it either checks for the correct property or it checks for the name service. 

### Description

Added solution to check for name service in the jdbc layer of the connector. 

### Related Issue

https://github.com/vertica/spark-connector/issues/248

### Additional Reviewers

@alexr-bq 
@alexey-temnikov 
@jonathanl-bq 