### PR TITLE
Support for replacing varchar and varbinary types in external tables

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -359,19 +359,11 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
                 .toRight(MissingNameNodeAddressError())
               _ = logger.debug("Hadoop impersonation: name node address: " + nameNodeAddress)
               encodedDelegationToken <- fileStoreLayer.getImpersonationToken(cfg.auth.user)
-              jsonString = Option(hadoopConf.get(HdfsClientConfigKeys.DFS_NAMESERVICES)) match {
-                case Some(nameservice) => s"""
-                  {
-                     "nameservice": "$nameservice",
-                     "token": "$encodedDelegationToken"
-                  }"""
-
-                case None => s"""
-                  {
-                     "authority": "$nameNodeAddress",
-                     "token": "$encodedDelegationToken"
-                  }"""
-              }
+              jsonString = s"""
+                {
+                   "authority": "$nameNodeAddress",
+                   "token": "$encodedDelegationToken"
+                }"""
               sql = s"ALTER SESSION SET HadoopImpersonationConfig='[$jsonString]'"
               _ <- this.execute(sql)
             } yield ()

--- a/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
@@ -444,22 +444,20 @@ class SchemaTools extends SchemaToolsInterface {
     val schemaList = schemaString.split(",").toList
 
     val updatedSchema: String = schemaList.map(col => {
-      if(col.contains(unknown)) {
-        val indexOfFirstDoubleQuote = col.indexOf("\"")
-        val indexOfSpace = col.indexOf(" ", indexOfFirstDoubleQuote)
-        val colName = col.substring(indexOfFirstDoubleQuote, indexOfSpace)
+      val indexOfFirstDoubleQuote = col.indexOf("\"")
+      val indexOfSpace = col.indexOf(" ", indexOfFirstDoubleQuote)
+      val colName = col.substring(indexOfFirstDoubleQuote, indexOfSpace)
 
-        val fieldType = schema.collect {
-          case field if(addDoubleQuotes(field.name) == colName) => field.dataType.simpleString
-        }
-        if(fieldType.nonEmpty) {
-          colName + " " + fieldType.head
-        }
-        else {
-          col
-        }
+      val fieldType = schema.collect {
+        case field if(addDoubleQuotes(field.name) == colName) => field.dataType.simpleString
       }
-      else { col }
+      if(fieldType.nonEmpty) {
+        colName + " " + fieldType.head
+      }
+
+      else {
+        col
+      }
     }).mkString(",")
 
     if(updatedSchema.contains(unknown)) {

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -543,7 +543,7 @@ class SchemaToolsTests extends AnyFlatSpec with BeforeAndAfterAll with MockFacto
     val createExternalTableStmt = "create external table \"sales\"(" +
       "\"tx_id\" int," +
       "\"date\" UNKNOWN," +
-      "\"region\" UNKNOWN" +
+      "\"region\" varchar" +
       ") as copy from \'/data/\' parquet"
     val schemaTools = new SchemaTools
     schemaTools.inferExternalTableSchema(createExternalTableStmt, schema, "sales") match {


### PR DESCRIPTION
### Summary

This change allows users to replace any column types in their parquet data when creating an external table instead of only being restricted to partitioned columns. 

### Description

Removed condition where we check if column type is "UNKNOWN" so that we only check to see if provided column name matches inferred column name before changing the column type. Also, log a warning if varchar or varbinary are detected in the inferred schema. This is because the lengths of these column types cannot be inferred and are truncated to the default vertica size (80).

### Related Issue

https://github.com/vertica/spark-connector/issues/262

### Additional Reviewers

@jonathanl-bq 
@alexey-temnikov 
@alexr-bq 
