### PR TITLE
Fix docker container names

### DIFF
--- a/docker/docker-compose-kerberos.yml
+++ b/docker/docker-compose-kerberos.yml
@@ -2,6 +2,7 @@ version: "3.9"
 services:
   krbclient:
     build: ./client-krb
+    container_name: docker_krbclient_1
     networks:
       - "example"
     domainname: "example.com"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,11 +2,13 @@ version: "3.9"
 services:
   client:
     build: .
+    container_name: docker_client_1
     volumes:
       - "./..:/spark-connector"
     stdin_open: true
   vertica:
     image: "vertica/vertica-k8s"
+    container_name: docker_vertica_1
     entrypoint: ["/bin/bash", "-c", "/opt/vertica/bin/docker-entrypoint.sh"]
 
     ports:
@@ -15,6 +17,7 @@ services:
       - ./vertica-hdfs-config/hadoop:/etc/hadoop/conf
   hdfs:
     image: "mdouchement/hdfs"
+    container_name: docker_hdfs_1
     ports:
       - "22022:22"
       - "8020:8020"


### PR DESCRIPTION
### Summary

Due to the new Docker update, container names included dashes instead of underscores, which broke environment setup scripts. 

### Description

Specify names with underscores in docker compose files. 

### Related Issue

https://github.com/vertica/spark-connector/issues/270

### Additional Reviewers

@jonathanl-bq 
@alexr-bq 
@alexey-temnikov 
