### PR TITLE
Support for Spark 3.2.0

### DIFF
--- a/connector/build.sbt
+++ b/connector/build.sbt
@@ -65,7 +65,6 @@ coverageFailOnMinimum := true
 
 assembly / assemblyShadeRules := Seq(
   ShadeRule.rename("cats.**" -> "shadeCats.@1").inAll
-//  ShadeRule.rename("org.apache.spark.sql.**" -> "shadeSpark.@1").inAll
 )
 
 assembly / assemblyExcludedJars := {

--- a/connector/build.sbt
+++ b/connector/build.sbt
@@ -21,8 +21,8 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
 libraryDependencies += "com.vertica.jdbc" % "vertica-jdbc" % "10.0.1-0"
-libraryDependencies += "org.apache.spark" %% "spark-core" % "3.1.1"
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.1.1"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "3.2.0"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.2.0"
 libraryDependencies += "org.apache.hadoop" % "hadoop-hdfs" % "3.3.0"
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.2" % Test
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.2" % "test"
@@ -65,6 +65,7 @@ coverageFailOnMinimum := true
 
 assembly / assemblyShadeRules := Seq(
   ShadeRule.rename("cats.**" -> "shadeCats.@1").inAll
+//  ShadeRule.rename("org.apache.spark.sql.**" -> "shadeSpark.@1").inAll
 )
 
 assembly / assemblyExcludedJars := {

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -50,6 +50,8 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
   private val logger = LogProvider.getLogger(classOf[VerticaDistributedFilesystemWritePipe])
   private val tempTableName = TableName(config.tablename.name + "_" + config.sessionId, None)
   private val cleanupUtils = new CleanupUtils
+  private val LEGACY_PARQUET_REBASE_MODE_IN_WRITE = "spark.sql.legacy.parquet.datetimeRebaseModeInWrite"
+  private val LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE = "spark.sql.legacy.parquet.int96RebaseModeInWrite"
 
   /**
    * No write metadata required for configuration as of yet.
@@ -78,10 +80,8 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
   private def setSparkCalendarConf(): Unit = {
     SparkSession.getActiveSession match {
       case Some(session) =>
-        session.sparkContext.setLocalProperty("spark.sql.legacy.parquet.datetimeRebaseModeInWrite", "CORRECTED")
-        // don't use SQLConf because that breaks things for users on Spark 3.0
-        session.sparkContext.setLocalProperty("spark.sql.legacy.parquet.int96RebaseModeInWrite"
-          , "CORRECTED")
+        session.sparkContext.setLocalProperty(LEGACY_PARQUET_REBASE_MODE_IN_WRITE, "CORRECTED")
+        session.sparkContext.setLocalProperty(LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE, "CORRECTED")
       case None => logger.warn("No spark session found to set config")
     }
   }

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -22,6 +22,7 @@ import com.vertica.spark.util.error.CreateExternalTableAlreadyExistsError
 import com.vertica.spark.util.error._
 import com.vertica.spark.util.schema.SchemaToolsInterface
 import com.vertica.spark.util.table.TableUtilsInterface
+import com.vertica.spark.util.cleanup.CleanupUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
@@ -48,6 +49,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
 
   private val logger = LogProvider.getLogger(classOf[VerticaDistributedFilesystemWritePipe])
   private val tempTableName = TableName(config.tablename.name + "_" + config.sessionId, None)
+  private val cleanupUtils = new CleanupUtils
 
   /**
    * No write metadata required for configuration as of yet.
@@ -76,7 +78,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
   private def setSparkCalendarConf(): Unit = {
     SparkSession.getActiveSession match {
       case Some(session) =>
-        session.sparkContext.setLocalProperty(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE.key , "CORRECTED")
+        session.sparkContext.setLocalProperty("spark.sql.legacy.parquet.datetimeRebaseModeInWrite", "CORRECTED")
         // don't use SQLConf because that breaks things for users on Spark 3.0
         session.sparkContext.setLocalProperty("spark.sql.legacy.parquet.int96RebaseModeInWrite"
           , "CORRECTED")
@@ -151,7 +153,13 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
     val address = config.fileStoreConfig.address
     val delimiter = if(address.takeRight(1) == "/" || address.takeRight(1) == "\\") "" else "/"
     val filename = address + delimiter + uniqueId + ".parquet"
-    fileStoreLayer.openWriteParquetFile(filename)
+    fileStoreLayer.openWriteParquetFile(filename) match {
+      case Left(err) =>
+        logger.info("Cleaning up all files in path: " + address)
+        fileStoreLayer.removeDir(address)
+        Left(err)
+      case Right(()) => Right()
+    }
   }
 
   def writeData(data: DataBlock): ConnectorResult[Unit] = {

--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -211,9 +211,9 @@ class HadoopFileStoreLayer(fileStoreConfig : FileStoreConfig, schema: Option[Str
   hdfsConfig.set(SQLConf.PARQUET_INT96_AS_TIMESTAMP.key, "true")
   hdfsConfig.set(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, "false")
   hdfsConfig.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "INT96")
-  hdfsConfig.set(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE.key, "CORRECTED")
-  hdfsConfig.set(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_READ.key, "CORRECTED")
-  // don't use SQLConf because that breaks things for users on Spark 3.0
+  // Don't use SQLConf because that breaks things for users on Spark 3.2
+  hdfsConfig.set("spark.sql.legacy.parquet.datetimeRebaseModeInWrite", "CORRECTED")
+  hdfsConfig.set("spark.sql.legacy.parquet.datetimeRebaseModeInRead", "CORRECTED")
   hdfsConfig.set("spark.sql.legacy.parquet.int96RebaseModeInWrite", "CORRECTED")
   hdfsConfig.setEnum(ParquetOutputFormat.JOB_SUMMARY_LEVEL, JobSummaryLevel.NONE)
   hdfsConfig.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "000")

--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -157,6 +157,10 @@ class HadoopFileStoreLayer(fileStoreConfig : FileStoreConfig, schema: Option[Str
   private val SWEBHDFS_DELEGATION_TOKEN_TEXT = new Text("SWEBHDFS delegation")
   private val HDFS_DELEGATION_TOKEN_TEXT = new Text("HDFS_DELEGATION_TOKEN")
 
+  private val LEGACY_PARQUET_REBASE_MODE_IN_WRITE = "spark.sql.legacy.parquet.datetimeRebaseModeInWrite"
+  private val LEGACY_PARQUET_REBASE_MODE_IN_READ =  "spark.sql.legacy.parquet.datetimeRebaseModeInRead"
+  private val LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE = "spark.sql.legacy.parquet.int96RebaseModeInWrite"
+
   private var writer: Option[ParquetWriter[InternalRow]] = None
   private var reader: Option[HadoopFileStoreReader] = None
 
@@ -212,9 +216,9 @@ class HadoopFileStoreLayer(fileStoreConfig : FileStoreConfig, schema: Option[Str
   hdfsConfig.set(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, "false")
   hdfsConfig.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "INT96")
   // Don't use SQLConf because that breaks things for users on Spark 3.2
-  hdfsConfig.set("spark.sql.legacy.parquet.datetimeRebaseModeInWrite", "CORRECTED")
-  hdfsConfig.set("spark.sql.legacy.parquet.datetimeRebaseModeInRead", "CORRECTED")
-  hdfsConfig.set("spark.sql.legacy.parquet.int96RebaseModeInWrite", "CORRECTED")
+  hdfsConfig.set(LEGACY_PARQUET_REBASE_MODE_IN_WRITE, "CORRECTED")
+  hdfsConfig.set(LEGACY_PARQUET_REBASE_MODE_IN_READ, "CORRECTED")
+  hdfsConfig.set(LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE, "CORRECTED")
   hdfsConfig.setEnum(ParquetOutputFormat.JOB_SUMMARY_LEVEL, JobSummaryLevel.NONE)
   hdfsConfig.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "000")
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -297,6 +297,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
     (fileStoreLayerInterface.openWriteParquetFile _).expects(*).returning(Left(OpenWriteError(new Exception())))
+    (fileStoreLayerInterface.removeDir _).expects(*).returning(Right(()))
+
 
     val tableUtils = mock[TableUtilsInterface]
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -299,7 +299,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (fileStoreLayerInterface.openWriteParquetFile _).expects(*).returning(Left(OpenWriteError(new Exception())))
     (fileStoreLayerInterface.removeDir _).expects(*).returning(Right(()))
 
-
     val tableUtils = mock[TableUtilsInterface]
 
     val pipe = new VerticaDistributedFilesystemWritePipe(config, fileStoreLayerInterface, jdbcLayerInterface, schemaToolsInterface, tableUtils)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,11 +9,11 @@ RUN yum install -y java-11-openjdk && \
     curl -L https://www.scala-sbt.org/sbt-rpm.repo > sbt-rpm.repo && \
     mv sbt-rpm.repo /etc/yum.repos.d/ && \
     yum -y install sbt && \
-    wget https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz && \
+    wget https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-without-hadoop.tgz && \
     wget https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz && \
-    tar xvf spark-3.1.2-bin-without-hadoop.tgz && \
+    tar xvf spark-3.0.0-bin-without-hadoop.tgz && \
     tar xvf hadoop-3.3.0.tar.gz && \
-    mv spark-3.1.2-bin-without-hadoop/ /opt/spark && \
+    mv spark-3.0.0-bin-without-hadoop/ /opt/spark && \
     cd /opt/spark/conf && \
     mv spark-env.sh.template spark-env.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,11 +9,11 @@ RUN yum install -y java-11-openjdk && \
     curl -L https://www.scala-sbt.org/sbt-rpm.repo > sbt-rpm.repo && \
     mv sbt-rpm.repo /etc/yum.repos.d/ && \
     yum -y install sbt && \
-    wget https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-without-hadoop.tgz && \
+    wget https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-without-hadoop.tgz && \
     wget https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz && \
-    tar xvf spark-3.0.0-bin-without-hadoop.tgz && \
+    tar xvf spark-3.1.2-bin-without-hadoop.tgz && \
     tar xvf hadoop-3.3.0.tar.gz && \
-    mv spark-3.0.0-bin-without-hadoop/ /opt/spark && \
+    mv spark-3.1.2-bin-without-hadoop/ /opt/spark && \
     cd /opt/spark/conf && \
     mv spark-env.sh.template spark-env.sh
 

--- a/examples/basic-read-example/build.sbt
+++ b/examples/basic-read-example/build.sbt
@@ -21,8 +21,8 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "org.apache.spark" %% "spark-core" % "3.0.0",
-  "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "org.apache.spark" %% "spark-core" % "3.2.0",
+  "org.apache.spark" %% "spark-sql" % "3.2.0",
   "com.vertica.spark" % "vertica-spark" % "2.0.4-slim"
 )
 

--- a/examples/basic-write-example/build.sbt
+++ b/examples/basic-write-example/build.sbt
@@ -21,8 +21,8 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "org.apache.spark" %% "spark-core" % "3.0.0",
-  "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "org.apache.spark" %% "spark-core" % "3.2.0",
+  "org.apache.spark" %% "spark-sql" % "3.2.0",
   "com.vertica.spark" % "vertica-spark" % "2.0.4-slim"
 )
 

--- a/examples/external-table-example/build.sbt
+++ b/examples/external-table-example/build.sbt
@@ -21,8 +21,8 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "org.apache.spark" %% "spark-core" % "3.0.2",
-  "org.apache.spark" %% "spark-sql" % "3.0.2",
+  "org.apache.spark" %% "spark-core" % "3.2.0",
+  "org.apache.spark" %% "spark-sql" % "3.2.0",
   "com.vertica.spark" % "vertica-spark" % "2.0.4-slim"
 )
 

--- a/examples/kerberos-example/build.sbt
+++ b/examples/kerberos-example/build.sbt
@@ -21,8 +21,8 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "org.apache.spark" %% "spark-core" % "3.0.0",
-  "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "org.apache.spark" %% "spark-core" % "3.2.0",
+  "org.apache.spark" %% "spark-sql" % "3.2.0",
   "com.vertica.spark" % "vertica-spark" % "2.0.4-slim"
 )
 

--- a/examples/merge-example/build.sbt
+++ b/examples/merge-example/build.sbt
@@ -21,8 +21,8 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "org.apache.spark" %% "spark-core" % "3.0.0",
-  "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "org.apache.spark" %% "spark-core" % "3.2.0",
+  "org.apache.spark" %% "spark-sql" % "3.2.0",
   "com.vertica.spark" % "vertica-spark" % "2.0.4-slim"
 )
 

--- a/examples/s3-example/build.sbt
+++ b/examples/s3-example/build.sbt
@@ -21,8 +21,8 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",
-  "org.apache.spark" %% "spark-core" % "3.0.0",
-  "org.apache.spark" %% "spark-sql" % "3.0.0",
+  "org.apache.spark" %% "spark-core" % "3.2.0",
+  "org.apache.spark" %% "spark-sql" % "3.2.0",
   "org.apache.hadoop" % "hadoop-aws" % "3.3.0",
   "com.vertica.spark" % "vertica-spark" % "2.0.4-slim"
 )

--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-scalaVersion := "2.12.12"
+scalaVersion := "2.12.13"
 name := "spark-vertica-connector-functional-tests"
 organization := "com.vertica"
 version := "2.0.4"
 
-val sparkVersion = Option(System.getProperty("sparkVersion")).getOrElse("3.0.2")
+val sparkVersion = Option(System.getProperty("sparkVersion")).getOrElse("3.1.2")
 val hadoopVersion = Option(System.getProperty("hadoopVersion")).getOrElse("2.4.1")
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"

--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.12.12"
 name := "spark-vertica-connector-functional-tests"
 organization := "com.vertica"
 version := "2.0.4"

--- a/functional-tests/project/plugins.sbt
+++ b/functional-tests/project/plugins.sbt
@@ -1,3 +1,4 @@
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addDependencyTreePlugin


### PR DESCRIPTION
### Summary

Made changes to connector to support Spark version 3.2.0 in addition to 3.1 and 3.0.

### Description

Changed spark-sql and spark-core versions in our connector to 3.2. Use spark.sql.legacy.parquet instead of SqlConf to set local config properties. Adjusted func-tests so that they support correct error types and messages. 

### Related Issue

https://github.com/vertica/spark-connector/issues/272

### Additional Reviewers

@jonathanl-bq 
@alexr-bq 
@alexey-temnikov 
