### PR TITLE
Support hdfs uri without the filesystem modifier at the front

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/config/FileStoreConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/FileStoreConfig.scala
@@ -60,7 +60,7 @@ final case class FileStoreConfig(baseAddress: String, sessionId: String, awsOpti
           val hadoopConf = session.sparkContext.hadoopConfiguration
           val filepath = Option(hadoopConf.get("fs.defaultFS")) match {
             case Some(path) => Right(path)
-            case None => Left(HDFSConfigError())
+            case None => Left(HDFSConfigError().context("No fs.defaultFS value supplied in HDFS config"))
           }
           filepath
         case None => Left(NoSparkSessionFound())

--- a/connector/src/main/scala/com/vertica/spark/util/error/ErrorHandling.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/error/ErrorHandling.scala
@@ -483,6 +483,9 @@ case class InferExternalTableSchemaError(error: ConnectorError) extends Connecto
   def getFullContext: String = ErrorHandling.appendErrors(this.message, this.error.getFullContext)
   override def getUserMessage: String = ErrorHandling.appendErrors(this.message, this.error.getUserMessage)
 }
+case class HDFSConfigError() extends ConnectorError {
+  override def getFullContext: String = "No value specified for property: \"fs.defaultFS\" in core-site.xml"
+}
 case class JobAbortedError() extends ConnectorError {
   def getFullContext: String = "Writing job aborted. Check spark worker log for specific error."
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: docker_client_1
     volumes:
       - "./..:/spark-connector"
+      - "./vertica-hdfs-config/hadoop:/etc/hadoop/conf"
     stdin_open: true
   vertica:
     image: "vertica/vertica-k8s"

--- a/docker/sandbox-clientenv.sh
+++ b/docker/sandbox-clientenv.sh
@@ -44,6 +44,7 @@ else
   docker compose -f docker-compose.yml up -d
   docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
   docker exec docker_vertica_1 /bin/sh -c "sudo /usr/sbin/sshd -D"
+  docker exec docker_client_1 /bin/sh -c "cp /etc/hadoop/conf/* /hadoop-3.3.0/etc/hadoop/"
   docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
   docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
   docker exec docker_hdfs_1 /opt/hadoop/sbin/stop-dfs.sh


### PR DESCRIPTION
### Summary

This change allows users to specify the filepath portion of the uri without the filesystem modifier at the front.

### Description

Filesystem modifer is now sourced from core-site.xml and prefixed with the supplied filepath. Most of the change is reflected in FileStoreConfig.

### Related Issue

https://github.com/vertica/spark-connector/issues/259

### Additional Reviewers

@jonathanl-bq 
@alexr-bq 
