### PR TITLE
Snappy encoding

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -152,7 +152,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
   def startPartitionWrite(uniqueId: String): ConnectorResult[Unit] = {
     val address = config.fileStoreConfig.address
     val delimiter = if(address.takeRight(1) == "/" || address.takeRight(1) == "\\") "" else "/"
-    val filename = address + delimiter + uniqueId + ".parquet"
+    val filename = address + delimiter + uniqueId + ".snappy.parquet"
     fileStoreLayer.openWriteParquetFile(filename) match {
       case Left(err) =>
         logger.info("Cleaning up all files in path: " + address)

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -274,7 +274,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val dataBlock = DataBlock(List(InternalRow(v1, v2), InternalRow(v1, v3)))
 
     val fileStoreLayerInterface = mock[FileStoreLayerInterface]
-    (fileStoreLayerInterface.openWriteParquetFile _).expects(fileStoreConfig.address + "/" + uniqueId + ".parquet").returning(Right(()))
+    (fileStoreLayerInterface.openWriteParquetFile _).expects(fileStoreConfig.address + "/" + uniqueId + ".snappy.parquet").returning(Right(()))
     (fileStoreLayerInterface.writeDataToParquetFile _).expects(dataBlock).returning(Right(()))
     (fileStoreLayerInterface.closeWriteParquetFile _).expects().returning(Right(()))
 


### PR DESCRIPTION
### Summary

Include .snappy in the parquet file name, similar to the format used by the default spark parquet writer.

### Description

Included .snappy encoding in filename when starting partition write. 

### Related Issue

https://github.com/vertica/spark-connector/issues/252

### Additional Reviewers

@alexr-bq 
@jonathanl-bq 
@alexey-temnikov 
