### PR TITLE
Remove dbschema option from external-table-example

### DIFF
--- a/examples/external-table-example/src/main/resources/application.conf
+++ b/examples/external-table-example/src/main/resources/application.conf
@@ -6,6 +6,5 @@ functional-tests {
   password=""
   filepath="webhdfs://hdfs:50070/3.1.1/"
   external="existing-data"
-  dbschema="test"
 }
 

--- a/examples/external-table-example/src/main/scala/example/Main.scala
+++ b/examples/external-table-example/src/main/scala/example/Main.scala
@@ -30,8 +30,7 @@ object Main  {
       "db" -> conf.getString("functional-tests.db"),
       "staging_fs_url" -> conf.getString("functional-tests.filepath"),
       "password" -> conf.getString("functional-tests.password"),
-      "create_external_table" -> conf.getString("functional-tests.external"),
-      "dbschema" -> conf.getString("functional-tests.dbschema")
+      "create_external_table" -> conf.getString("functional-tests.external")
     )
     // Entry-point to all functionality in Spark
     val spark = SparkSession.builder()


### PR DESCRIPTION
### Summary

Remove dbschema option from external-table-example. Prior to this change, this example could not be run out of the box.

### Description

Same as above

### Related Issue

https://github.com/vertica/spark-connector/issues/288

### Additional Reviewers

@jeremyp-bq 
@alexey-temnikov 
@jonathanl-bq 
@alexr-bq 
