### PR TITLE
Log rejected data table results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .bsp/
 target/
 
+.bloop/
 .idea/
 .metals/
 .vscode/

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -374,6 +374,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
           rs <- jdbcLayer.query(rejectsDataQuery)
           _ = Try {
             val rsmd = rs.getMetaData
+            logger.error(s"Found $rejectedCount rejected rows, displaying up to the first 10:")
             logger.error((1 to rsmd.getColumnCount).map(idx => rsmd.getColumnName(idx)).toList.mkString(" | "))
             while (rs.next) {
               logger.error((1 to rsmd.getColumnCount).map(idx => rs.getString(idx)).toList.mkString(" | "))

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -373,9 +373,10 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
         for {
           rs <- jdbcLayer.query(rejectsDataQuery)
           _ = Try {
-            logger.error("file_name | row_number | rejected_data | rejected_reason")
+            val rsmd = rs.getMetaData
+            logger.error((1 to rsmd.getColumnCount).map(idx => rsmd.getColumnName(idx)).toList.mkString(" | "))
             while (rs.next) {
-              logger.error(s"${rs.getString(1)} | ${rs.getString(2)} | ${rs.getString(3)} | ${rs.getString(4)}")
+              logger.error((1 to rsmd.getColumnCount).map(idx => rs.getString(idx)).toList.mkString(" | "))
             }
           }
           _ = rs.close()

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -71,6 +71,15 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     resultSet
   }
 
+  private def getStringByIndexTableResultSet(): ResultSet = {
+    val resultSet = mock[ResultSet]
+    (resultSet.next _).expects().returning(true)
+    (resultSet.getString(_: Int)).expects(*)
+    (resultSet.close _).expects().returning(())
+
+    resultSet
+  }
+
   private def getStringResultSet(): ResultSet = {
     val resultSet = mock[ResultSet]
     (resultSet.next _).expects().returning(true)
@@ -500,6 +509,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getCountTableResultSet(6)))
+    (jdbcLayerInterface.query _).expects(*,*).returning(Right(getStringByIndexTableResultSet))
     (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
 
@@ -533,6 +543,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getCountTableResultSet(4)))
+    (jdbcLayerInterface.query _).expects(*,*).returning(Right(getStringByIndexTableResultSet))
     (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -71,10 +71,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     resultSet
   }
 
-  private def getStringByIndexTableResultSet(): ResultSet = {
+  private def getClosedResultSet(): ResultSet = {
     val resultSet = mock[ResultSet]
-    (resultSet.next _).expects().returning(true)
-    (resultSet.getString(_: Int)).expects(*)
     (resultSet.close _).expects().returning(())
 
     resultSet
@@ -509,7 +507,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getCountTableResultSet(6)))
-    (jdbcLayerInterface.query _).expects(*,*).returning(Right(getStringByIndexTableResultSet))
+    (jdbcLayerInterface.query _).expects(*,*).returning(Right(getClosedResultSet))
     (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.rollback _).expects().returning(Right(()))
 
@@ -543,7 +541,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getEmptyResultSet))
     (jdbcLayerInterface.executeUpdate _).expects(*,*).returning(Right(100))
     (jdbcLayerInterface.query _).expects(*,*).returning(Right(getCountTableResultSet(4)))
-    (jdbcLayerInterface.query _).expects(*,*).returning(Right(getStringByIndexTableResultSet))
+    (jdbcLayerInterface.query _).expects(*,*).returning(Right(getClosedResultSet))
     (jdbcLayerInterface.close _).expects().returning(Right(()))
     (jdbcLayerInterface.commit _).expects().returning(Right(()))
 


### PR DESCRIPTION
### Summary

Log rejected data table results

### Description

The rejected data table is never persisted in the Vertica (it is a temporary table), so the user cannot see the exact reason for any rejected rows.  This change logs the first few rows (10) from the rejected data table.  Only the columns that are  most helpful in narrowing down the error are printed (file_name, row_number, rejected_data, and rejected_data_reason).

Trying to persist the table was difficult due to our commit logic, but it can be address as part of #293.

This is a sample of what the rejected data table might contain (not persisted):
```sql
     node_name     |                                     file_name                                     |         session_id          |  transaction_id   | statement_id | batch_number | row_number | rejected_data | rejected_data_orig_length |                    rejected_reason
-------------------+-----------------------------------------------------------------------------------+-----------------------------+-------------------+--------------+--------------+------------+---------------+---------------------------+-------------------------------------------------------
 v_docker_node0001 | webhdfs://hdfs:50070/data/1a4212fb_b2c8_4998_9c1f_09d14b1f9e4a/0-0.snappy.parquet | v_docker_node0001-99:0x57cd | 45035996273707541 |           27 |            0 |          1 | NULL          |                         4 | In column 1: Cannot set NULL value in NOT NULL column
```

And this is a sample of what will now be printed in the logs if there is at least one rejected row (this example has 1 rejected row):
```sh
21/12/14 18:58:13 INFO VerticaDistributedFilesystemWritePipe: Checking number of rejected rows via statement: SELECT COUNT(*) as count FROM "dftest_a3b77254_d039_46cf_98ff_e1cbf81a9c57_COMMITS"
21/12/14 18:58:13 INFO VerticaDistributedFilesystemWritePipe: Verifying rows saved to Vertica is within user tolerance...
21/12/14 18:58:13 INFO VerticaDistributedFilesystemWritePipe: Number of rows_rejected=1. rows_copied=3. failedRowsPercent=0.25. user's failed_rows_percent_tolerance=0.5. passedFaultToleranceTest=true...PASSED.  OK to commit to database.
21/12/14 18:58:13 INFO VerticaDistributedFilesystemWritePipe: Getting rejected rows via statement: SELECT file_name, row_number, rejected_data, rejected_reason FROM "dftest_a3b77254_d039_46cf_98ff_e1cbf81a9c57_COMMITS" LIMIT 10
21/12/14 18:58:13 ERROR VerticaDistributedFilesystemWritePipe: file_name | row_number | rejected_data | rejected_reason
21/12/14 18:58:13 ERROR VerticaDistributedFilesystemWritePipe: webhdfs://hdfs:50070/data/a3b77254_d039_46cf_98ff_e1cbf81a9c57/0-0.snappy.parquet | 1 | NULL | In column 1: Cannot set NULL value in NOT NULL column
```

### Related Issue

#275

### Additional Reviewers

@alexr-bq
@alexey-temnikov
@jonathanl-bq
@ravjotbrar
