### PR TITLE
Update kdc dockerfile to mimic systemctl 

### DIFF
--- a/docker/kdc/Dockerfile
+++ b/docker/kdc/Dockerfile
@@ -1,19 +1,20 @@
 FROM centos:8
 
  RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
- systemd-tmpfiles-setup.service ] || rm -f $i; done); \
- rm -f /lib/systemd/system/multi-user.target.wants/*;\
- rm -f /etc/systemd/system/*.wants/*;\
- rm -f /lib/systemd/system/local-fs.target.wants/*; \
- rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
- rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
- rm -f /lib/systemd/system/basic.target.wants/*;\
- rm -f /lib/systemd/system/anaconda.target.wants/*;
- RUN yum install python2 wget -y
- RUN  wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py -O /usr/local/bin/systemctl
- RUN chmod a+x /usr/local/bin/systemctl
- RUN yum -y install initscripts && yum clean all
- RUN yum install krb5-server krb5-libs krb5-workstation -y
+     systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+     rm -f /lib/systemd/system/multi-user.target.wants/*;\
+     rm -f /etc/systemd/system/*.wants/*;\
+     rm -f /lib/systemd/system/local-fs.target.wants/*; \
+     rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+     rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+     rm -f /lib/systemd/system/basic.target.wants/*;\
+     rm -f /lib/systemd/system/anaconda.target.wants/* && \
+     yum install python2 wget -y && \
+     wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py -O /usr/local/bin/systemctl && \
+     chmod a+x /usr/local/bin/systemctl && \
+     yum -y install initscripts && yum clean all && \
+     yum install krb5-server krb5-libs krb5-workstation -y
+
  EXPOSE 88
 
  CMD ["/usr/sbin/init"]

--- a/docker/kdc/Dockerfile
+++ b/docker/kdc/Dockerfile
@@ -1,4 +1,19 @@
-FROM centos:7
-RUN yum install krb5-server krb5-libs krb5-workstation -y
-EXPOSE 88
-CMD /sbin/init
+FROM centos:8
+
+ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+ systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+ rm -f /lib/systemd/system/multi-user.target.wants/*;\
+ rm -f /etc/systemd/system/*.wants/*;\
+ rm -f /lib/systemd/system/local-fs.target.wants/*; \
+ rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+ rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+ rm -f /lib/systemd/system/basic.target.wants/*;\
+ rm -f /lib/systemd/system/anaconda.target.wants/*;
+ RUN yum install python2 wget -y
+ RUN  wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py -O /usr/local/bin/systemctl
+ RUN chmod a+x /usr/local/bin/systemctl
+ RUN yum -y install initscripts && yum clean all
+ RUN yum install krb5-server krb5-libs krb5-workstation -y
+ EXPOSE 88
+
+ CMD ["/usr/sbin/init"]


### PR DESCRIPTION
### Summary

Update kdc dockerfile to mimic systemctl

### Description

Dockerfile changed to:
```
FROM centos:8

 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
 systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\
 rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 RUN yum install python2 wget -y
 RUN  wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py -O /usr/local/bin/systemctl
 RUN chmod a+x /usr/local/bin/systemctl
 RUN yum -y install initscripts && yum clean all
 RUN yum install krb5-server krb5-libs krb5-workstation -y
 EXPOSE 88

 CMD ["/usr/sbin/init"]

```

### Related Issue
https://github.com/vertica/spark-connector/issues/299

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
@jeremyp-bq 
