### PR TITLE
Do not create a job status table for external tables

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -150,7 +150,11 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
       _ <- if(existingData) Right(()) else fileStoreLayer.createDir(getAddress(), perm.toString)
 
       // Create job status table / entry
-      _ <- if(config.createExternalTable.isDefined) Right(()) else tableUtils.createAndInitJobStatusTable(config.tablename, config.jdbcConfig.auth.user, config.sessionId, if(config.isOverwrite) "OVERWRITE" else "APPEND")
+      _ <- if(config.createExternalTable.isDefined) {
+        Right(())
+      } else {
+        tableUtils.createAndInitJobStatusTable(config.tablename, config.jdbcConfig.auth.user, config.sessionId, if(config.isOverwrite) "OVERWRITE" else "APPEND")
+      }
     } yield ()
   }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -150,7 +150,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
       _ <- if(existingData) Right(()) else fileStoreLayer.createDir(getAddress(), perm.toString)
 
       // Create job status table / entry
-      _ <- tableUtils.createAndInitJobStatusTable(config.tablename, config.jdbcConfig.auth.user, config.sessionId, if(config.isOverwrite) "OVERWRITE" else "APPEND")
+      _ <- if(config.createExternalTable.isDefined) Right(()) else tableUtils.createAndInitJobStatusTable(config.tablename, config.jdbcConfig.auth.user, config.sessionId, if(config.isOverwrite) "OVERWRITE" else "APPEND")
     } yield ()
   }
 
@@ -494,8 +494,6 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
               )
 
       _ <- tableUtils.validateExternalTable(config.tablename)
-
-      _ <- tableUtils.updateJobStatusTable(config.tablename, config.jdbcConfig.auth.user, 0.0, config.sessionId, true)
 
     } yield ()
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -211,7 +211,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (tableUtils.viewExists _).expects(tablename).returning(Right(false))
     (tableUtils.tempTableExists _).expects(tablename).returning(Right(false))
     (tableUtils.tableExists _).expects(tablename).returning(Right(true))
-    (tableUtils.createAndInitJobStatusTable _).expects(tablename, jdbcConfig.auth.user, "id", "APPEND").returning(Right(()))
 
     // Should skip
     (tableUtils.createTable _).expects(tablename, None, schema, strlen).returning(Right()).never()
@@ -611,7 +610,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val tableUtils = mock[TableUtilsInterface]
     (tableUtils.createExternalTable _).expects(tname, config.targetTableSql, config.schema, config.strlen, expectedUrl).returning(Right(()))
     (tableUtils.validateExternalTable _).expects(tname).returning(Right(()))
-    (tableUtils.updateJobStatusTable _).expects(tname, jdbcConfig.auth.user, 0.0, "id", true).returning(Right(()))
 
     val pipe = new VerticaDistributedFilesystemWritePipe(config, fileStoreLayerInterface, jdbcLayerInterface, schemaToolsInterface, tableUtils)
 
@@ -641,7 +639,6 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     val tableUtils = mock[TableUtilsInterface]
     (tableUtils.createExternalTable _).expects(tname, Some(createExternalTableStmt), config.schema, config.strlen, url).returning(Right(()))
     (tableUtils.validateExternalTable _).expects(tname).returning(Right(()))
-    (tableUtils.updateJobStatusTable _).expects(tname, jdbcConfig.auth.user, 0.0, "id", true).returning(Right(()))
 
     val pipe = new VerticaDistributedFilesystemWritePipe(config, fileStoreLayerInterface, jdbcLayerInterface, schemaToolsInterface, tableUtils)
 


### PR DESCRIPTION
### Summary

Do not create a job status table for external tables.

### Description

When using external tables, do not create the status table in Vertica.  For non-external tables, the status table is still created.

In the future we will add an option to make the status table optional for non-external tables as well (see #308).

### Related Issue

Closes #290 

### Additional Reviewers

@alexey-temnikov 
@alexr-bq
@jonathanl-bq
@aryex