### PR TITLE
Opened debug port for docker environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,12 @@ Follow our [S3 user manual](https://github.com/vertica/spark-connector/blob/main
 
 At this point, you're ready to make your changes. Feel free to reach out over github for help navigating the code and implementing the fix or feature.
 
+## Debuging on Docker environment.
+
+If you are using docker as your dev enviroment, you can setup a debug server as well. For example, to debug `basic-read-example` running on docker, loggin to the client container and navigate to `basic-read-example` root folder. Then, run `sbt -jvm-debug *:5005` to start an sbt debug server at port `5005`. The `*` means that it will exception connections from any host. Then, connect your debugger to port `5005`. 
+
+If you would like to change the port number, edit `docker-compose.yml` under the `docker` folder. Currently, the client container is mapping its port `5005` to the host's `5005`.
+
 ### Connector Architecture
 
 The connector has a core architecture, which is called by an implementation of the Spark Datasource V2 API.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,9 +135,11 @@ Follow our [S3 user manual](https://github.com/vertica/spark-connector/blob/main
 
 At this point, you're ready to make your changes. Feel free to reach out over github for help navigating the code and implementing the fix or feature.
 
-## Debuging on Docker environment.
+## Debugging on Docker environment.
 
-If you are using docker as your dev enviroment, you can setup a debug server. For example, to debug `basic-read-example` running on docker, loggin to the client container and navigate to `basic-read-example` root folder. Then, run `sbt -jvm-debug *:5005` to start an sbt debug server at port `5005`. The `*` means that it will exception connections from any host. The sbt server is now up and waiting for commands. Connect your debugger to port `5005`, then type `run` into sbt to start compilation and execution.
+If you are using docker as your dev enviroment, you can setup a debug server. For example, to debug `basic-read-example` running on docker, loggin to the client container and navigate to `basic-read-example` root folder. Then, run `sbt -jvm-debug *:5005` to start an sbt debug server at port `5005`. The `*` means that it will exception connections from any host. 
+
+The sbt server is now up and waiting for commands. Connect your debugger to port `5005`, then type `run` into sbt to start compilation and execution.
 
 If you would like to change the port number, edit `docker-compose.yml` located under the `docker` folder. Currently, `docker_client_1` container is mapping its port `5005` to the host's `5005`. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,9 +137,9 @@ At this point, you're ready to make your changes. Feel free to reach out over gi
 
 ## Debuging on Docker environment.
 
-If you are using docker as your dev enviroment, you can setup a debug server as well. For example, to debug `basic-read-example` running on docker, loggin to the client container and navigate to `basic-read-example` root folder. Then, run `sbt -jvm-debug *:5005` to start an sbt debug server at port `5005`. The `*` means that it will exception connections from any host. Then, connect your debugger to port `5005`. 
+If you are using docker as your dev enviroment, you can setup a debug server. For example, to debug `basic-read-example` running on docker, loggin to the client container and navigate to `basic-read-example` root folder. Then, run `sbt -jvm-debug *:5005` to start an sbt debug server at port `5005`. The `*` means that it will exception connections from any host. The sbt server is now up and waiting for commands. Connect your debugger to port `5005`, then type `run` into sbt to start compilation and execution.
 
-If you would like to change the port number, edit `docker-compose.yml` under the `docker` folder. Currently, the client container is mapping its port `5005` to the host's `5005`.
+If you would like to change the port number, edit `docker-compose.yml` located under the `docker` folder. Currently, `docker_client_1` container is mapping its port `5005` to the host's `5005`. 
 
 ### Connector Architecture
 

--- a/docker/docker-compose-kerberos.yml
+++ b/docker/docker-compose-kerberos.yml
@@ -14,7 +14,7 @@ services:
     env_file:
       - "krb.env"
     ports:
-      - "5050:5050"
+      - "5005:5005"
   kdc:
     build: ./kdc
     container_name: "kdc"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./vertica-hdfs-config/hadoop:/etc/hadoop/conf
     stdin_open: true
     ports:
-      - 5005:5005
+      - "5005:5005"
   vertica:
     image: vertica/vertica-k8s
     container_name: docker_vertica_1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - ./..:/spark-connector
       - ./vertica-hdfs-config/hadoop:/etc/hadoop/conf
     stdin_open: true
+    ports:
+      - 5005:5005
   vertica:
     image: vertica/vertica-k8s
     container_name: docker_vertica_1

--- a/examples/kerberos-example/README.md
+++ b/examples/kerberos-example/README.md
@@ -66,7 +66,7 @@ Change directory to the example project directory `spark-connector/examples/kerb
 ./run-kerberos-example.sh 
 ```
 
-## Debuging.
+## Debugging.
 
 To debug, run `./run-kerberos-example.sh debug`. The execution will wait on port `5005` until a debugger connects to it before continuing with the execution. 
 

--- a/examples/kerberos-example/README.md
+++ b/examples/kerberos-example/README.md
@@ -66,6 +66,12 @@ Change directory to the example project directory `spark-connector/examples/kerb
 ./run-kerberos-example.sh 
 ```
 
+## Debuging.
+
+To debug, run `./run-kerberos-example.sh debug`. The execution will wait on port `5005` until a debugger connects to it before continuing with the execution. 
+
+To change the port number, edit `docker-compose-kerberos.yml`, currently, `docker_krbclient_1` container is mapping its `5005` port to host's `5005`.
+
 ## Tear down containers
 
 Exit out of the interactive terminal by running `exit`. 

--- a/examples/kerberos-example/run-kerberos-example.sh
+++ b/examples/kerberos-example/run-kerberos-example.sh
@@ -6,6 +6,6 @@ start-master.sh
 start-worker.sh spark://localhost:7077
 if [ "$1" == "debug" ]
   then
-    export SPARK_SUBMIT_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5050
+    export SPARK_SUBMIT_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005
 fi
 spark-submit --master spark://localhost:7077 --conf "spark.driver.extraClassPath={$SPARK_HOME}/conf/" --driver-java-options '-Djava.security.auth.login.config=/spark-connector/docker/client-krb/jaas.config' ./target/scala-2.12/spark-vertica-connector-kerberos-example-assembly-3.0.2.jar


### PR DESCRIPTION
### Summary

Open debug port on client container.

### Description

Opened port 5005 on docker_client_1 container for normal docker environment. For Kerberos, port 5050 is already opened for debug. 

### Additional Reviewers
@jeremyp-bq 
@alexr-bq 
@jonathanl-bq 
@alexey-temnikov 
