### PR TITLE
Use a single JDBC layer per read/write

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
@@ -53,13 +53,17 @@ object VerticaPipeFactory extends VerticaPipeFactoryInterface {
           case _ => None
         })
         val jdbcLayer = readLayer match {
-          case Some(readLayer) => readLayer
+          case Some(layer) => {
+            if (layer.isClosed()) {
+              readLayer = Some(new VerticaJdbcLayer(cfg.jdbcConfig))
+            }
+            readLayer.get
+          }
           case None => {
             readLayer = Some(new VerticaJdbcLayer(cfg.jdbcConfig))
             readLayer.get
           }
         }
-        // TODO: Reopen the connection if it is closed
         new VerticaDistributedFilesystemReadPipe(cfg, hadoopFileStoreLayer,
           jdbcLayer,
           new SchemaTools,
@@ -73,13 +77,17 @@ object VerticaPipeFactory extends VerticaPipeFactoryInterface {
       case cfg: DistributedFilesystemWriteConfig =>
         val schemaTools = new SchemaTools
         val jdbcLayer = writeLayer match {
-          case Some(writeLayer) => writeLayer
+          case Some(layer) => {
+            if (layer.isClosed()) {
+              writeLayer = Some(new VerticaJdbcLayer(cfg.jdbcConfig))
+            }
+            writeLayer.get
+          }
           case None => {
             writeLayer = Some(new VerticaJdbcLayer(cfg.jdbcConfig))
             writeLayer.get
           }
         }
-        // TODO: Reopen the connection if it is closed
         new VerticaDistributedFilesystemWritePipe(cfg,
           new HadoopFileStoreLayer(cfg.fileStoreConfig, Some(cfg.schema)),
           jdbcLayer,

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -307,9 +307,6 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
 
   def isClosed(): Boolean = {
     logger.debug("Checking if connection is closed.")
-    //this.connection.flatMap(conn => this.useConnection(conn, c => c.isClosed(), handleJDBCException)
-      //.left.map(_.context("rollback: JDBC Error while checking if connection is closed.")))
-      //.fold(_ => true, _ => false)
     this.connection.fold(_ => true, conn => conn.isClosed())
   }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -82,6 +82,11 @@ trait JdbcLayerInterface {
   def rollback(): ConnectorResult[Unit]
 
   /**
+    * Checks if the connection is closed
+    */
+  def isClosed(): Boolean
+
+  /**
    * Configures the database session
    *
    * @param fileStoreLayer Interface to a filestore that provides an impersonation token via getImpersonationToken
@@ -298,6 +303,14 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
     logger.debug("Rolling back.")
     this.connection.flatMap(conn => this.useConnection(conn, c => c.rollback(), handleJDBCException)
       .left.map(_.context("rollback: JDBC Error while rolling back.")))
+  }
+
+  def isClosed(): Boolean = {
+    logger.debug("Checking if connection is closed.")
+    //this.connection.flatMap(conn => this.useConnection(conn, c => c.isClosed(), handleJDBCException)
+      //.left.map(_.context("rollback: JDBC Error while checking if connection is closed.")))
+      //.fold(_ => true, _ => false)
+    this.connection.fold(_ => true, conn => conn.isClosed())
   }
 
   def configureSession(fileStoreLayer: FileStoreLayerInterface): ConnectorResult[Unit] = {


### PR DESCRIPTION
### Summary

Use a single JDBC layer, which holds the actual connection, for read or write operations.

### Description

We create a new JDBC layer, and thus a new connection, each time a read or write pipe is called for.  This results in additional connections at runtime, some of which are not closed when the operation completes.  This fix recreates the JDBC layer each time it is called, if the underlying connection was closed.

Further work is still needed to avoid opening and closing multiple connections, which will be performed under another ticket.

### Related Issue

Closes #314.

### Additional Reviewers

@alexey-temnikov
@alexr-bq
@Aryex
@jonathanl-bq
