### PR TITLE
Pushdown aggregate

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
@@ -51,7 +51,6 @@ trait ReadConfig {
 
   def setPushdownAggregation(aggregation: Aggregation): Unit
 
-  def getPushdownAggregation():Aggregation
 }
 
 
@@ -107,7 +106,7 @@ final case class DistributedFilesystemReadConfig(
                                                   timeOperations : Boolean = true
                                                 ) extends ReadConfig {
   private var pushdownFilters: List[PushdownFilter] = Nil
-  private var pushdownAggregation: Aggregation = _
+  private var pushdownAggregation: Aggregation = new Aggregation(Array(),Array())
   private var requiredSchema: StructType = StructType(Nil)
 
   def setPushdownFilters(pushdownFilters: List[PushdownFilter]): Unit = {
@@ -118,16 +117,17 @@ final case class DistributedFilesystemReadConfig(
     this.requiredSchema = requiredSchema
   }
 
+  override def setPushdownAggregation(aggregation: Aggregation): Unit = {
+    this.pushdownAggregation = aggregation
+  }
+
   def getPushdownFilters: List[PushdownFilter] = this.pushdownFilters
   def getRequiredSchema: StructType = this.requiredSchema
+  def getPushdownAggregation: Aggregation = this.pushdownAggregation
 
   def copyConfig(): ReadConfig = {
     this.copy(fileStoreConfig = this.fileStoreConfig.copy(sessionId = SessionId.getId))
   }
 
-  override def setPushdownAggregation(aggregation: Aggregation): Unit = {
-    this.pushdownAggregation = aggregation
-  }
 
-  override def getPushdownAggregation(): Aggregation = this.pushdownAggregation
 }

--- a/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
@@ -18,6 +18,7 @@ import com.vertica.spark.datasource.core.DSConfigSetupUtils.ValidationResult
 import com.vertica.spark.datasource.core.SessionId
 import com.vertica.spark.datasource.v2.PushdownFilter
 import com.vertica.spark.util.error.{InvalidFilePermissions, UnquotedSemiInColumns}
+import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
 import org.apache.spark.sql.types.StructType
 
 import scala.util.{Failure, Success, Try}
@@ -48,9 +49,9 @@ trait ReadConfig {
    */
   def copyConfig(): ReadConfig
 
-  def setPushdownCount(value:Boolean): Unit
+  def setPushdownAggregation(aggregation: Aggregation): Unit
 
-  def getPushdownCount():Boolean
+  def getPushdownAggregation():Aggregation
 }
 
 
@@ -106,6 +107,7 @@ final case class DistributedFilesystemReadConfig(
                                                   timeOperations : Boolean = true
                                                 ) extends ReadConfig {
   private var pushdownFilters: List[PushdownFilter] = Nil
+  private var pushdownAggregation: Aggregation = _
   private var requiredSchema: StructType = StructType(Nil)
 
   def setPushdownFilters(pushdownFilters: List[PushdownFilter]): Unit = {
@@ -123,10 +125,9 @@ final case class DistributedFilesystemReadConfig(
     this.copy(fileStoreConfig = this.fileStoreConfig.copy(sessionId = SessionId.getId))
   }
 
-  private var pushdownCount = false
-  override def setPushdownCount(value: Boolean): Unit = {
-    this.pushdownCount = value
+  override def setPushdownAggregation(aggregation: Aggregation): Unit = {
+    this.pushdownAggregation = aggregation
   }
 
-  override def getPushdownCount(): Boolean = this.pushdownCount
+  override def getPushdownAggregation(): Aggregation = this.pushdownAggregation
 }

--- a/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/ReadConfig.scala
@@ -47,6 +47,10 @@ trait ReadConfig {
    * Copies the read config with a new unique identifier
    */
   def copyConfig(): ReadConfig
+
+  def setPushdownCount(value:Boolean): Unit
+
+  def getPushdownCount():Boolean
 }
 
 
@@ -118,4 +122,11 @@ final case class DistributedFilesystemReadConfig(
   def copyConfig(): ReadConfig = {
     this.copy(fileStoreConfig = this.fileStoreConfig.copy(sessionId = SessionId.getId))
   }
+
+  private var pushdownCount = false
+  override def setPushdownCount(value: Boolean): Unit = {
+    this.pushdownCount = value
+  }
+
+  override def getPushdownCount(): Boolean = this.pushdownCount
 }

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -185,13 +185,13 @@ class VerticaDistributedFilesystemReadPipe(
 
   private def getSelectClause: ConnectorResult[String] = {
       val pushdownAggregations = this.config.getPushdownAggregation.aggregateExpressions()
-      if(pushdownAggregations.isEmpty) getColumnNames(this.config.getRequiredSchema) else this.getAggregateColumns
+      if(pushdownAggregations.isEmpty) getColumnNames(this.config.getRequiredSchema) else this.getPushdownAggregateColumns
   }
 
-  private def getAggregateColumns: ConnectorResult[String] = {
+  private def getPushdownAggregateColumns: ConnectorResult[String] = {
     val pushdownAggregates = this.config.getPushdownAggregation.aggregateExpressions
     val aggregateSelectClause = pushdownAggregates.map {
-      case agg: CountStar => agg.toString + " as \"count(a)\""
+      case agg: CountStar => agg.toString + " as \"" + this.config.getRequiredSchema.fields.head + "\""
       case agg: Count => agg.toString +  " as \"" + agg.column.describe + "\""
       case _ => ""
     }.mkString(", ")

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
@@ -105,7 +105,7 @@ class VerticaScanBuilder(config: ReadConfig, readConfigSetup: DSConfigSetupInter
   }
 
   override def pushAggregation(aggregation: Aggregation): Boolean = {
-    // Only support Count for now.
+    // We do this because only count is supported.
     val supportedAggregateFunctions = aggregation.aggregateExpressions().filter {
       case _:CountStar => true
       case _:Count => true

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
@@ -125,7 +125,7 @@ class VerticaScanBuilder(config: ReadConfig, readConfigSetup: DSConfigSetupInter
           val colName = this.getFirstColumnName().getOrElse("")
           StructField(colName, LongType, nullable = false, Metadata.empty)
 
-        case f: Count => StructField(f.column.fieldNames.head, LongType, nullable = false, Metadata.empty)
+        case f: Count => StructField(f.column.describe(), LongType, nullable = false, Metadata.empty)
       }
       this.requiredSchema = StructType(structFields)
       this.aggregation = new Aggregation(supportedAggregateFunctions.toArray, Array())

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Read.scala
@@ -46,7 +46,7 @@ case class ExpectedRowDidNotExistError() extends ConnectorError {
   * Builds the scan class for use in reading of Vertica
   */
 class VerticaScanBuilder(config: ReadConfig, readConfigSetup: DSConfigSetupInterface[ReadConfig]) extends ScanBuilder with
-  SupportsPushDownFilters  with SupportsPushDownRequiredColumns {
+  SupportsPushDownFilters with SupportsPushDownAggregates  with SupportsPushDownRequiredColumns {
   private var pushFilters: List[PushFilter] = Nil
 
   private var requiredSchema: StructType = StructType(Nil)
@@ -94,6 +94,11 @@ class VerticaScanBuilder(config: ReadConfig, readConfigSetup: DSConfigSetupInter
   //  pushdownCount = true
   //  true
   //}
+
+  override def pushAggregation(aggregation: Aggregation): Boolean = {
+
+    false
+  }
 }
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - ./..:/spark-connector
       - ./vertica-hdfs-config/hadoop:/etc/hadoop/conf
     stdin_open: true
+    ports:
+      - 5005:5005
   vertica:
     image: vertica/vertica-k8s
     container_name: docker_vertica_1


### PR DESCRIPTION
### Summary

Add push down support for count

### Description
Implemented pushdown aggregate support for count operations.
Aggregate pushdown was first introduced by Spark in 3.2 and thus is not available if you use an older spark version. 

### Related Issue
Closes #319 
#326

### Additional Reviewers
@alexey-temnikov 
@alexr-bq 
@jeremyp-bq 
@jonathanl-bq 
