### PR TITLE
Turn off codecov patch check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,4 @@ coverage:
         # basic
         target: 80
         threshold: 1%
+    patch: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,6 @@ coverage:
         # basic
         target: 80
         threshold: 1%
-    patch: off
+    patch:
+      default:
+        target: 80


### PR DESCRIPTION
### Summary

Updated codecov.yml to turn off patch status check on each PR. Patch status only looks at the coverage of the PR it self.
https://docs.codecov.com/docs/commit-status#patch-status
