### PR TITLE
Fix Compatibility with Spark 3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The connector relies on a distributed filesystem, such as HDFS, to act as a brid
 
 To get started with using the connector, we'll need to make sure all the prerequisites are in place. These are:
 - A Vertica installation
+- Spark 3.0.0 or higher
 - An HDFS cluster or S3 bucket, for use as an intermediary between Spark and Vertica
 - A spark application, either running locally for quick testing, or running on a spark cluster. If using S3, Spark must be using hadoop 3.3
 
@@ -35,6 +36,8 @@ For an easier quick test of the connector using a dockerized environment, see [t
 Follow the [Vertica Documenation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/InstallationGuide/Other/InstallationGuide.htm) for steps on installing Vertica.
 
 ### Spark
+
+The connector requires Spark 3.0.0 or higher.
 
 There are several examples of spark programs that use this connector in the [examples](/examples) directory. 
 
@@ -225,10 +228,6 @@ For information on how to configure Kerberos and TLS with the connector, see the
 For information on tuning performance, see [here in our performance-tests section.](performance-tests/README.md)
 
 ## Limitations
-
-The connector supports versions of Spark between 3.0 and 3.1.1.
-
-The connector supports basic Spark types. Complex types are not currently supported (arrays, maps, structs).
 
 If using S3 rather than HDFS, the spark cluster must be running with hadoop 3.3. Our [S3 user manual](https://github.com/vertica/spark-connector/blob/main/S3UserManual.md) goes over how to configure this.
 

--- a/connector/build.sbt
+++ b/connector/build.sbt
@@ -30,8 +30,8 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
 libraryDependencies += "com.vertica.jdbc" % "vertica-jdbc" % "11.0.2-0"
-libraryDependencies += "org.apache.spark" %% "spark-core" % "3.2.0"
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.2.0"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "latest.release"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "latest.release"
 libraryDependencies += "org.apache.hadoop" % "hadoop-hdfs" % "3.3.0"
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.2" % Test
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.2" % "test"

--- a/connector/src/main/scala/com/vertica/spark/parquet/ParquetRowConverter.scala
+++ b/connector/src/main/scala/com/vertica/spark/parquet/ParquetRowConverter.scala
@@ -18,19 +18,19 @@
 
 package org.apache.spark.sql.execution.datasources.parquet.vertica
 
+import com.vertica.spark.parquet.VerticaDataSourceUtils
+import com.vertica.spark.parquet.vertica.VerticaDataSourceUtils
+
 import java.math.{BigDecimal, BigInteger}
 import java.nio.ByteOrder
 import java.time.{ZoneId, ZoneOffset}
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
-
 import org.apache.parquet.column.Dictionary
 import org.apache.parquet.io.api.{Binary, Converter, GroupConverter, PrimitiveConverter}
 import org.apache.parquet.schema.{GroupType, OriginalType, Type}
 import org.apache.parquet.schema.OriginalType.LIST
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.{BINARY, FIXED_LEN_BYTE_ARRAY, INT32, INT64, INT96}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -189,13 +189,13 @@ private[parquet] class ParquetRowConverter(
    */
   def currentRecord: InternalRow = currentRow
 
-  private val dateRebaseFunc = DataSourceUtils.creteDateRebaseFuncInRead(
+  private val dateRebaseFunc = VerticaDataSourceUtils.createDateRebaseFuncInRead(
     datetimeRebaseMode, "Parquet")
 
-  private val timestampRebaseFunc = DataSourceUtils.creteTimestampRebaseFuncInRead(
+  private val timestampRebaseFunc = VerticaDataSourceUtils.createTimestampRebaseFuncInRead(
     datetimeRebaseMode, "Parquet")
 
-  private val int96RebaseFunc = DataSourceUtils.creteTimestampRebaseFuncInRead(
+  private val int96RebaseFunc = VerticaDataSourceUtils.createTimestampRebaseFuncInRead(
     int96RebaseMode, "Parquet INT96")
 
   // Converters for each field.

--- a/connector/src/main/scala/com/vertica/spark/parquet/ParquetRowConverter.scala
+++ b/connector/src/main/scala/com/vertica/spark/parquet/ParquetRowConverter.scala
@@ -21,18 +21,20 @@ package org.apache.spark.sql.execution.datasources.parquet.vertica
 import java.math.{BigDecimal, BigInteger}
 import java.nio.ByteOrder
 import java.time.{ZoneId, ZoneOffset}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.parquet.column.Dictionary
 import org.apache.parquet.io.api.{Binary, Converter, GroupConverter, PrimitiveConverter}
 import org.apache.parquet.schema.{GroupType, OriginalType, Type}
 import org.apache.parquet.schema.OriginalType.LIST
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.{BINARY, FIXED_LEN_BYTE_ARRAY, INT32, INT64, INT96}
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, CaseInsensitiveMap, DateTimeUtils, GenericArrayData}
-import org.apache.spark.sql.execution.datasources.DataSourceUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.types._

--- a/connector/src/main/scala/com/vertica/spark/parquet/ParquetRowConverter.scala
+++ b/connector/src/main/scala/com/vertica/spark/parquet/ParquetRowConverter.scala
@@ -18,9 +18,6 @@
 
 package org.apache.spark.sql.execution.datasources.parquet.vertica
 
-import com.vertica.spark.parquet.VerticaDataSourceUtils
-import com.vertica.spark.parquet.vertica.VerticaDataSourceUtils
-
 import java.math.{BigDecimal, BigInteger}
 import java.nio.ByteOrder
 import java.time.{ZoneId, ZoneOffset}

--- a/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.execution.datasources.parquet.vertica
 
 import org.apache.spark.sql.catalyst.util.RebaseDateTime

--- a/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
@@ -1,14 +1,18 @@
-package com.vertica.spark.parquet.vertica
+package org.apache.spark.sql.execution.datasources.parquet.vertica
 
 import org.apache.spark.sql.catalyst.util.RebaseDateTime
 import org.apache.spark.sql.execution.datasources.DataSourceUtils
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 
 /**
+ * Copied from Spark 3.2.0 DataSourceUtils implementation.
  *
+ * Classes under the parquet package were copied from Spark for reading parquet into Spark. It is not a public API and
+ * thus is expected to change. In Spark 3.2.1, the DataSourceUtils interface was changed. To fix this, this class
+ * copied from Spark 3.2.0 only the needed functions.
  * */
 object VerticaDataSourceUtils {
-  // DONT DELETE
+
   def createDateRebaseFuncInRead(
                                  rebaseMode: LegacyBehaviorPolicy.Value,
                                  format: String): Int => Int = rebaseMode match {
@@ -21,7 +25,6 @@ object VerticaDataSourceUtils {
     case LegacyBehaviorPolicy.CORRECTED => identity[Int]
   }
 
-  // DONT DELETE
   def createTimestampRebaseFuncInRead(
                                       rebaseMode: LegacyBehaviorPolicy.Value,
                                       format: String): Long => Long = rebaseMode match {

--- a/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
@@ -26,6 +26,9 @@ import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
  * */
 object VerticaDataSourceUtils {
 
+  /**
+   * Create a function that rebase a given datetime value
+   * */
   def createDateRebaseFuncInRead(
                                  rebaseMode: LegacyBehaviorPolicy.Value,
                                  format: String): Int => Int = rebaseMode match {
@@ -38,6 +41,9 @@ object VerticaDataSourceUtils {
     case LegacyBehaviorPolicy.CORRECTED => identity[Int]
   }
 
+  /**
+   * Create a function that rebase a given timestamp value
+   * */
   def createTimestampRebaseFuncInRead(
                                       rebaseMode: LegacyBehaviorPolicy.Value,
                                       format: String): Long => Long = rebaseMode match {

--- a/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
@@ -1,19 +1,15 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// (c) Copyright [2020-2021] Micro Focus or one of its affiliates.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package org.apache.spark.sql.execution.datasources.parquet.vertica
 

--- a/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
  * Copied from Spark 3.2.0 DataSourceUtils implementation.
  *
  * Classes under the parquet package were copied from Spark for reading parquet into Spark. It is not a public API and
- * thus is expected to change. In Spark 3.2.1, the DataSourceUtils interface was changed. To fix this, this class
+ * thus is expected to change. In Spark 3.2.1, the DataSourceUtils interface was changed. As a fix, this class
  * copied from Spark 3.2.0 only the needed functions.
  * */
 object VerticaDataSourceUtils {

--- a/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/parquet/VerticaDataSourceUtils.scala
@@ -1,0 +1,36 @@
+package com.vertica.spark.parquet.vertica
+
+import org.apache.spark.sql.catalyst.util.RebaseDateTime
+import org.apache.spark.sql.execution.datasources.DataSourceUtils
+import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
+
+/**
+ *
+ * */
+object VerticaDataSourceUtils {
+  // DONT DELETE
+  def createDateRebaseFuncInRead(
+                                 rebaseMode: LegacyBehaviorPolicy.Value,
+                                 format: String): Int => Int = rebaseMode match {
+    case LegacyBehaviorPolicy.EXCEPTION => days: Int =>
+      if (days < RebaseDateTime.lastSwitchJulianDay) {
+        throw DataSourceUtils.newRebaseExceptionInRead(format)
+      }
+      days
+    case LegacyBehaviorPolicy.LEGACY => RebaseDateTime.rebaseJulianToGregorianDays
+    case LegacyBehaviorPolicy.CORRECTED => identity[Int]
+  }
+
+  // DONT DELETE
+  def createTimestampRebaseFuncInRead(
+                                      rebaseMode: LegacyBehaviorPolicy.Value,
+                                      format: String): Long => Long = rebaseMode match {
+    case LegacyBehaviorPolicy.EXCEPTION => micros: Long =>
+      if (micros < RebaseDateTime.lastSwitchJulianTs) {
+        throw DataSourceUtils.newRebaseExceptionInRead(format)
+      }
+      micros
+    case LegacyBehaviorPolicy.LEGACY => RebaseDateTime.rebaseJulianToGregorianMicros
+    case LegacyBehaviorPolicy.CORRECTED => identity[Long]
+  }
+}


### PR DESCRIPTION
### Summary

Fixes compatibility with Spark3.2.1

### Description

Added VerticaDataSourceUtils, which copied only the needed coded form Spark 3.2.0

### Related Issue

Closes #364 

### Additional Reviewers
@alexr-bq 
@jeremyp-bq 
@jonathanl-bq 
