### PR TITLE
Add partial support for GCS as done for AWS S3

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import cats.implicits._
 import com.typesafe.scalalogging.Logger
-import com.vertica.spark.config.{AWSAuth, AWSOptions, FileStoreConfig, LogProvider}
+import com.vertica.spark.config.{AWSAuth, AWSOptions, FileStoreConfig, GCSOptions, LogProvider}
 import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
 import org.apache.hadoop.fs.permission.FsPermission
 import org.apache.hadoop.hdfs.DistributedFileSystem
@@ -79,6 +79,7 @@ trait FileStoreLayerInterface {
 
   def getImpersonationToken(user: String) : ConnectorResult[String]
   def getAWSOptions: AWSOptions
+  def getGCSOptions : GCSOptions
 }
 
 final case class HadoopFileStoreReader(reader: ParquetFileReader, columnIO: MessageColumnIO, recordConverter: RecordMaterializer[InternalRow], fileRange: ParquetFileRange) {
@@ -491,6 +492,10 @@ class HadoopFileStoreLayer(fileStoreConfig : FileStoreConfig, schema: Option[Str
 
   override def getAWSOptions: AWSOptions = {
     this.fileStoreConfig.awsOptions
+  }
+
+  override def getGCSOptions: GCSOptions = {
+    this.fileStoreConfig.gcsOptions
   }
 
   private def useFileSystem[T](filename: String,

--- a/connector/src/test/scala/com/vertica/spark/common/TestObjects.scala
+++ b/connector/src/test/scala/com/vertica/spark/common/TestObjects.scala
@@ -13,8 +13,8 @@
 
 package com.vertica.spark.common
 
-import com.vertica.spark.config.{AWSOptions, FileStoreConfig}
+import com.vertica.spark.config.{AWSOptions, FileStoreConfig, GCSOptions}
 
 object TestObjects {
-  val fileStoreConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", false, AWSOptions(None, None, None, None, None, None, None))
+  val fileStoreConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", false, AWSOptions(None, None, None, None, None, None, None), GCSOptions(None))
 }

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipeTests.scala
@@ -923,7 +923,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
   }
 
   it should "Not call cleanup when prevent_cleanup set to true" in {
-    val fsConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", true, AWSOptions(None, None, None, None, None, None, None))
+    val fsConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", true, AWSOptions(None, None, None, None, None, None, None), GCSOptions(None))
     val config = makeReadConfig.copy(fileStoreConfig = fsConfig)
 
     val v1: Int = 1
@@ -963,7 +963,7 @@ class VerticaDistributedFilesystemReadPipeTests extends AnyFlatSpec with BeforeA
   }
 
   it should "prevent cleanup when preReadSteps returns an error" in {
-    val fsConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", true, AWSOptions(None, None, None, None, None, None, None))
+    val fsConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", true, AWSOptions(None, None, None, None, None, None, None), GCSOptions(None))
     val config = makeReadConfig.copy(fileStoreConfig = fsConfig)
 
     val fileStoreLayer = mock[FileStoreLayerInterface]

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -15,7 +15,7 @@ package com.vertica.spark.datasource.core
 
 import java.sql.ResultSet
 import com.vertica.spark.common.TestObjects
-import com.vertica.spark.config.{AWSOptions, BasicJdbcAuth, DistributedFilesystemWriteConfig, FileStoreConfig, JDBCConfig, JDBCTLSConfig, TableName, ValidColumnList, ValidFilePermissions}
+import com.vertica.spark.config.{AWSOptions, BasicJdbcAuth, DistributedFilesystemWriteConfig, FileStoreConfig, GCSOptions, JDBCConfig, JDBCTLSConfig, TableName, ValidColumnList, ValidFilePermissions}
 import com.vertica.spark.datasource.fs.FileStoreLayerInterface
 import com.vertica.spark.datasource.jdbc.JdbcLayerInterface
 import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
@@ -881,7 +881,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
   }
 
   it should "prevent cleanup of parquet files when prevent_cleanup set to true" in {
-    val fsConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", true, AWSOptions(None, None, None, None, None, None, None))
+    val fsConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", true, AWSOptions(None, None, None, None, None, None, None), GCSOptions(None))
     val config = createWriteConfig().copy(fileStoreConfig = fsConfig)
 
     val expected = "COPY \"dummy\"  FROM 'hdfs://example-hdfs:8020/tmp/test/*.parquet' ON ANY NODE parquet REJECTED DATA AS TABLE \"dummy_id_COMMITS\" NO COMMIT"
@@ -910,7 +910,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
   }
 
   it should "prevent cleanup if startPartitionWrite returns an error" in {
-    val fsConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", true, AWSOptions(None, None, None, None, None, None, None))
+    val fsConfig: FileStoreConfig = FileStoreConfig("hdfs://example-hdfs:8020/tmp/", "test", true, AWSOptions(None, None, None, None, None, None, None), GCSOptions(None))
     val config = createWriteConfig().copy(fileStoreConfig = fsConfig)
     val uniqueId = "unique-id"
     val jdbcLayerInterface = mock[JdbcLayerInterface]


### PR DESCRIPTION
### Summary

Current connector support only S3 as staging filesystem we need to use it with databricks on GCP 

### Description

Add some GCS configuration to support the `ALTER SESSION SET GCSAuth=<accessKey>:<secretKey>` in vertica
The access key and secret key are the same as supported for S3

To set you accessKey and secretKey:
``` 
val opt = Map("host" -> host, "table" -> table, "db" -> db, "num_partitions" -> part, "user" -> user, "password" -> password, "staging_fs_url" -> staging_fs_url, "port" -> port, "dbschema" -> dbschema, "gcs_access_key_id" -> "xxx", "gcs_secret_access_key" -> "xxx") 
```

### Related Issue

This code is actually working for us in Databricks GCP using databricks runtime 10.4LTS with spark 3.2.2

### Additional Reviewers

<!-- Any additional reviewers -->
