### PR TITLE
Fixing issue with Spark version resolution on EMR 

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Table.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Table.scala
@@ -88,12 +88,13 @@ class VerticaTable(caseInsensitiveStringMap: CaseInsensitiveStringMap, readSetup
         }
         logger.debug("Config loaded")
 
-        // Pushdown of aggregates added in spark 3.2, detect spark version so we return class with right feature support
+        // Aggregates push down were added in spark 3.2. We detect spark version here to return the compatible class
         var sparkNewerThan31 = true
         try {
-          val sparkVersion = SparkSession.getActiveSession.get.version
-          val versionList = sparkVersion.split("\\.").map(_.toInt)
-          if(versionList.length >= 2 && versionList(0) == 3 && versionList(1) < 2) {
+          val versionList = SparkSession.getActiveSession.get.version.split("\\.")
+          val major = versionList(0).toInt
+          val minor = versionList(1).toInt
+          if(versionList.length >= 2 && major == 3 && minor < 2) {
             sparkNewerThan31 = false
           }
         }

--- a/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Table.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/v2/VerticaDatasourceV2Table.scala
@@ -92,10 +92,12 @@ class VerticaTable(caseInsensitiveStringMap: CaseInsensitiveStringMap, readSetup
         var sparkNewerThan31 = true
         try {
           val versionList = SparkSession.getActiveSession.get.version.split("\\.")
-          val major = versionList(0).toInt
-          val minor = versionList(1).toInt
-          if(versionList.length >= 2 && major == 3 && minor < 2) {
-            sparkNewerThan31 = false
+          if (versionList.length >= 2) {
+            val major = versionList(0).toInt
+            val minor = versionList(1).toInt
+            if (major == 3 && minor < 2) {
+              sparkNewerThan31 = false
+            }
           }
         }
         catch { // Couldn't recgonize version string, assume newer version


### PR DESCRIPTION
### Summary

Spark Version parsing now only cast major and minor strings to avoid issue with EMR

### Related Issue

Closes #380 

### Additional Reviewers
@jeremyp-bq 
@jonathanl-bq 
@alexey-temnikov 
@alexr-bq 

