### PR TITLE
Fixed functional tests failing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,100 +44,100 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: true
           verbose: true
-#  run-integration-tests-spark-3-0-latest:
-#    runs-on: ubuntu-latest
-#    needs: build
-#    env:
-#      VERTICA_VERSION: 11.0.2-0
-#    steps:
-#      - name: Checkout the project
-#        uses: actions/checkout@v2
-#      - name: Run docker compose
-#        run: cd docker && docker-compose up -d
-##      - name: print Vertica version
-##        run: docker exec docker_vertica_1 vsql -c "select version();"
-#      - name: Create db in Vertica
-#        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
-#      - name: Replace HDFS core-site config with our own
-#        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
-#      - name: Replace HDFS hdfs-site config with our own
-#        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-#      - name: Copy partitioned parquet data to HDFS container
-#        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
-#      - name: Copy partitioned parquet data to hadoop from local
-#        uses: nick-invision/retry@v2
-#        with:
-#          timeout_seconds: 20
-#          max_attempts: 10
-#          retry_on: error
-#          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
-#      - name: Download the build artifact
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: build-jar-file
-#          path: ./functional-tests/lib/
-#      - name: Increase active sessions in database
-#        uses: nick-invision/retry@v2
-#        with:
-#          timeout_seconds: 20
-#          max_attempts: 10
-#          retry_on: error
-#          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
-#      - name: Copy functional tests to home directory of client container
-#        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
-#      - name: Copy version.properties file from client container
-#        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
-#      - name: Run the integration tests on Spark 3.0
-#        run: docker exec -w /home/functional-tests docker_client_1 sbt -DsparkVersion="3.0.2" -DhadoopVersion="2.4.0" "run -s EndToEndTests -t \"create an external table with existing data in FS\""
-#      - name: Remove docker containers
-#        run: cd docker && docker-compose down
-#  run-integration-tests-spark-3-1-latest:
-#    runs-on: ubuntu-latest
-#    needs: build
-#    env:
-#      VERTICA_VERSION: 11.0.2-0
-#    steps:
-#      - name: Checkout the project
-#        uses: actions/checkout@v2
-#      - name: Build client image
-#        run: docker build -t client ./docker
-#      - name: Run docker compose
-#        run: cd docker && docker-compose up -d
-#      - name: Create db in Vertica
-#        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
-#      - name: Replace HDFS core-site config with our own
-#        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
-#      - name: Replace HDFS hdfs-site config with our own
-#        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-#      - name: Copy partitioned parquet data to HDFS container
-#        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
-#      - name: Copy partitioned parquet data to hadoop from local
-#        uses: nick-invision/retry@v2
-#        with:
-#          timeout_seconds: 20
-#          max_attempts: 10
-#          retry_on: error
-#          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
-#      - name: Download the build artifact
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: build-jar-file
-#          path: ./functional-tests/lib/
-#      - name: Increase active sessions in database
-#        uses: nick-invision/retry@v2
-#        with:
-#          timeout_seconds: 20
-#          max_attempts: 10
-#          retry_on: error
-#          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
-#      - name: Copy functional tests to home directory of client container
-#        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
-#      - name: Copy version.properties file from client container
-#        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
-#      - name: Run the integration tests on Spark 3.1
-#        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
-#      - name: Remove docker containers
-#        run: cd docker && docker-compose down
+  run-integration-tests-spark-3-0-latest:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      VERTICA_VERSION: 11.0.2-0
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v2
+      - name: Run docker compose
+        run: cd docker && docker-compose up -d
+#      - name: print Vertica version
+#        run: docker exec docker_vertica_1 vsql -c "select version();"
+      - name: Create db in Vertica
+        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
+      - name: Replace HDFS core-site config with our own
+        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+      - name: Replace HDFS hdfs-site config with our own
+        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+      - name: Copy partitioned parquet data to HDFS container
+        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
+      - name: Copy partitioned parquet data to hadoop from local
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
+      - name: Download the build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-jar-file
+          path: ./functional-tests/lib/
+      - name: Increase active sessions in database
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+      - name: Copy functional tests to home directory of client container
+        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
+      - name: Copy version.properties file from client container
+        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
+      - name: Run the integration tests on Spark 3.0
+        run: docker exec -w /home/functional-tests docker_client_1 sbt -DsparkVersion="3.0.2" -DhadoopVersion="2.4.0" "run -s EndToEndTests -t \"create an external table with existing data in FS\""
+      - name: Remove docker containers
+        run: cd docker && docker-compose down
+  run-integration-tests-spark-3-1-latest:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      VERTICA_VERSION: 11.0.2-0
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v2
+      - name: Build client image
+        run: docker build -t client ./docker
+      - name: Run docker compose
+        run: cd docker && docker-compose up -d
+      - name: Create db in Vertica
+        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
+      - name: Replace HDFS core-site config with our own
+        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+      - name: Replace HDFS hdfs-site config with our own
+        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+      - name: Copy partitioned parquet data to HDFS container
+        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
+      - name: Copy partitioned parquet data to hadoop from local
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
+      - name: Download the build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-jar-file
+          path: ./functional-tests/lib/
+      - name: Increase active sessions in database
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+      - name: Copy functional tests to home directory of client container
+        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
+      - name: Copy version.properties file from client container
+        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
+      - name: Run the integration tests on Spark 3.1
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
+      - name: Remove docker containers
+        run: cd docker && docker-compose down
   run-integration-tests-spark-3-2-latest:
     runs-on: ubuntu-latest
     needs: build
@@ -182,6 +182,6 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.2
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="3.3.2"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="3.3.1"
       - name: Remove docker containers
         run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.0
-        run: docker exec -w /home/functional-tests docker_client_1 sbt -DsparkVersion="3.0.2" -DhadoopVersion="2.4.0" "run -s EndToEndTests -t \"create an external table with existing data in FS\""
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.0.0, 3.1.0)" -DhadoopVersion="[2.7.0, 2.8.0)"
       - name: Remove docker containers
         run: cd docker && docker-compose down
   run-integration-tests-spark-3-1-latest:
@@ -133,7 +133,7 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.1
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="[3.3.0, 3.4.0)"
       - name: Remove docker containers
         run: cd docker && docker-compose down
   run-integration-tests-spark-3-2-latest:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,8 +141,8 @@ jobs:
   run-integration-tests-spark-3-2-latest:
     runs-on: ubuntu-latest
     needs: build
-    env:
-      VERTICA_VERSION: 11.0.2-0
+#    env:
+#      VERTICA_VERSION: 11.0.2-0
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose
         run: cd docker && docker-compose up -d
-      - name: print Vertica version
-        run: docker exec docker_vertica_1 vsql -c "select version();"
+#      - name: print Vertica version
+#        run: docker exec docker_vertica_1 vsql -c "select version();"
       - name: Create db in Vertica
         run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
       - name: Replace HDFS core-site config with our own

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,11 +47,15 @@ jobs:
   run-integration-tests-spark-3-0-latest:
     runs-on: ubuntu-latest
     needs: build
+    env:
+      VERTICA_VERSION: 11.0.2-0
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
       - name: Run docker compose
         run: cd docker && docker-compose up -d
+      - name: print Vertica version
+        run: docker exec docker_vertica_1 vsql -c "select version();"
       - name: Create db in Vertica
         run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
       - name: Replace HDFS core-site config with our own

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,6 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.2
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="3.2.0" -DhadoopVersion="3.0.1"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="3.2.1" -DhadoopVersion="3.0.1"
       - name: Remove docker containers
         run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,6 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.2
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="[3.3.0, 3.4.0)"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="3.3.0"
       - name: Remove docker containers
         run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.1
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="3.3.1"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
       - name: Remove docker containers
         run: cd docker && docker-compose down
   run-integration-tests-spark-3-2-latest:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,93 +91,97 @@ jobs:
         run: docker exec -w /home/functional-tests docker_client_1 sbt -DsparkVersion="3.0.2" -DhadoopVersion="2.4.0" "run -s EndToEndTests -t \"create an external table with existing data in FS\""
       - name: Remove docker containers
         run: cd docker && docker-compose down
-#  run-integration-tests-spark-3-1-latest:
-#    runs-on: ubuntu-latest
-#    needs: build
-#    steps:
-#      - name: Checkout the project
-#        uses: actions/checkout@v2
-#      - name: Build client image
-#        run: docker build -t client ./docker
-#      - name: Run docker compose
-#        run: cd docker && docker-compose up -d
-#      - name: Create db in Vertica
-#        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
-#      - name: Replace HDFS core-site config with our own
-#        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
-#      - name: Replace HDFS hdfs-site config with our own
-#        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-#      - name: Copy partitioned parquet data to HDFS container
-#        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
-#      - name: Copy partitioned parquet data to hadoop from local
-#        uses: nick-invision/retry@v2
-#        with:
-#          timeout_seconds: 20
-#          max_attempts: 10
-#          retry_on: error
-#          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
-#      - name: Download the build artifact
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: build-jar-file
-#          path: ./functional-tests/lib/
-#      - name: Increase active sessions in database
-#        uses: nick-invision/retry@v2
-#        with:
-#          timeout_seconds: 20
-#          max_attempts: 10
-#          retry_on: error
-#          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
-#      - name: Copy functional tests to home directory of client container
-#        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
-#      - name: Copy version.properties file from client container
-#        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
-#      - name: Run the integration tests on Spark 3.1
-#        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
-#      - name: Remove docker containers
-#        run: cd docker && docker-compose down
-#  run-integration-tests-spark-3-2-latest:
-#    runs-on: ubuntu-latest
-#    needs: build
-#    steps:
-#      - name: Checkout the project
-#        uses: actions/checkout@v2
-#      - name: Build client image
-#        run: docker build -t client ./docker
-#      - name: Run docker compose
-#        run: cd docker && docker-compose up -d
-#      - name: Create db in Vertica
-#        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
-#      - name: Replace HDFS core-site config with our own
-#        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
-#      - name: Replace HDFS hdfs-site config with our own
-#        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-#      - name: Copy partitioned parquet data to HDFS container
-#        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
-#      - name: Copy partitioned parquet data to hadoop from local
-#        uses: nick-invision/retry@v2
-#        with:
-#          timeout_seconds: 20
-#          max_attempts: 10
-#          retry_on: error
-#          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
-#      - name: Download the build artifact
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: build-jar-file
-#          path: ./functional-tests/lib/
-#      - name: Increase active sessions in database
-#        uses: nick-invision/retry@v2
-#        with:
-#          timeout_seconds: 20
-#          max_attempts: 10
-#          retry_on: error
-#          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
-#      - name: Copy functional tests to home directory of client container
-#        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
-#      - name: Copy version.properties file from client container
-#        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
-#      - name: Run the integration tests on Spark 3.2
-#        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="[3.3.0, 3.4.0)"
-#      - name: Remove docker containers
-#        run: cd docker && docker-compose down
+  run-integration-tests-spark-3-1-latest:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      VERTICA_VERSION: 11.0.2-0
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v2
+      - name: Build client image
+        run: docker build -t client ./docker
+      - name: Run docker compose
+        run: cd docker && docker-compose up -d
+      - name: Create db in Vertica
+        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
+      - name: Replace HDFS core-site config with our own
+        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+      - name: Replace HDFS hdfs-site config with our own
+        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+      - name: Copy partitioned parquet data to HDFS container
+        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
+      - name: Copy partitioned parquet data to hadoop from local
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
+      - name: Download the build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-jar-file
+          path: ./functional-tests/lib/
+      - name: Increase active sessions in database
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+      - name: Copy functional tests to home directory of client container
+        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
+      - name: Copy version.properties file from client container
+        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
+      - name: Run the integration tests on Spark 3.1
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
+      - name: Remove docker containers
+        run: cd docker && docker-compose down
+  run-integration-tests-spark-3-2-latest:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      VERTICA_VERSION: 11.0.2-0
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v2
+      - name: Build client image
+        run: docker build -t client ./docker
+      - name: Run docker compose
+        run: cd docker && docker-compose up -d
+      - name: Create db in Vertica
+        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
+      - name: Replace HDFS core-site config with our own
+        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+      - name: Replace HDFS hdfs-site config with our own
+        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+      - name: Copy partitioned parquet data to HDFS container
+        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
+      - name: Copy partitioned parquet data to hadoop from local
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
+      - name: Download the build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-jar-file
+          path: ./functional-tests/lib/
+      - name: Increase active sessions in database
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+      - name: Copy functional tests to home directory of client container
+        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
+      - name: Copy version.properties file from client container
+        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
+      - name: Run the integration tests on Spark 3.2
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="[3.3.0, 3.4.0)"
+      - name: Remove docker containers
+        run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.0
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.0.0, 3.1.0)" -DhadoopVersion="[2.7.0, 2.8.0)"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="3.0.2" -DhadoopVersion="2.4.0"
       - name: Remove docker containers
         run: cd docker && docker-compose down
   run-integration-tests-spark-3-1-latest:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.1
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="3.3.1"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="3.3.1"
       - name: Remove docker containers
         run: cd docker && docker-compose down
   run-integration-tests-spark-3-2-latest:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,6 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.2
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="3.3.1"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="3.3.2"
       - name: Remove docker containers
         run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,100 +44,100 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: true
           verbose: true
-  run-integration-tests-spark-3-0-latest:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      VERTICA_VERSION: 11.0.2-0
-    steps:
-      - name: Checkout the project
-        uses: actions/checkout@v2
-      - name: Run docker compose
-        run: cd docker && docker-compose up -d
-#      - name: print Vertica version
-#        run: docker exec docker_vertica_1 vsql -c "select version();"
-      - name: Create db in Vertica
-        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
-      - name: Replace HDFS core-site config with our own
-        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
-      - name: Replace HDFS hdfs-site config with our own
-        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-      - name: Copy partitioned parquet data to HDFS container
-        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
-      - name: Copy partitioned parquet data to hadoop from local
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 20
-          max_attempts: 10
-          retry_on: error
-          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
-      - name: Download the build artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-jar-file
-          path: ./functional-tests/lib/
-      - name: Increase active sessions in database
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 20
-          max_attempts: 10
-          retry_on: error
-          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
-      - name: Copy functional tests to home directory of client container
-        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
-      - name: Copy version.properties file from client container
-        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
-      - name: Run the integration tests on Spark 3.0
-        run: docker exec -w /home/functional-tests docker_client_1 sbt -DsparkVersion="3.0.2" -DhadoopVersion="2.4.0" "run -s EndToEndTests -t \"create an external table with existing data in FS\""
-      - name: Remove docker containers
-        run: cd docker && docker-compose down
-  run-integration-tests-spark-3-1-latest:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      VERTICA_VERSION: 11.0.2-0
-    steps:
-      - name: Checkout the project
-        uses: actions/checkout@v2
-      - name: Build client image
-        run: docker build -t client ./docker
-      - name: Run docker compose
-        run: cd docker && docker-compose up -d
-      - name: Create db in Vertica
-        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
-      - name: Replace HDFS core-site config with our own
-        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
-      - name: Replace HDFS hdfs-site config with our own
-        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-      - name: Copy partitioned parquet data to HDFS container
-        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
-      - name: Copy partitioned parquet data to hadoop from local
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 20
-          max_attempts: 10
-          retry_on: error
-          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
-      - name: Download the build artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-jar-file
-          path: ./functional-tests/lib/
-      - name: Increase active sessions in database
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 20
-          max_attempts: 10
-          retry_on: error
-          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
-      - name: Copy functional tests to home directory of client container
-        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
-      - name: Copy version.properties file from client container
-        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
-      - name: Run the integration tests on Spark 3.1
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
-      - name: Remove docker containers
-        run: cd docker && docker-compose down
+#  run-integration-tests-spark-3-0-latest:
+#    runs-on: ubuntu-latest
+#    needs: build
+#    env:
+#      VERTICA_VERSION: 11.0.2-0
+#    steps:
+#      - name: Checkout the project
+#        uses: actions/checkout@v2
+#      - name: Run docker compose
+#        run: cd docker && docker-compose up -d
+##      - name: print Vertica version
+##        run: docker exec docker_vertica_1 vsql -c "select version();"
+#      - name: Create db in Vertica
+#        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
+#      - name: Replace HDFS core-site config with our own
+#        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+#      - name: Replace HDFS hdfs-site config with our own
+#        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+#      - name: Copy partitioned parquet data to HDFS container
+#        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
+#      - name: Copy partitioned parquet data to hadoop from local
+#        uses: nick-invision/retry@v2
+#        with:
+#          timeout_seconds: 20
+#          max_attempts: 10
+#          retry_on: error
+#          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
+#      - name: Download the build artifact
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: build-jar-file
+#          path: ./functional-tests/lib/
+#      - name: Increase active sessions in database
+#        uses: nick-invision/retry@v2
+#        with:
+#          timeout_seconds: 20
+#          max_attempts: 10
+#          retry_on: error
+#          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+#      - name: Copy functional tests to home directory of client container
+#        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
+#      - name: Copy version.properties file from client container
+#        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
+#      - name: Run the integration tests on Spark 3.0
+#        run: docker exec -w /home/functional-tests docker_client_1 sbt -DsparkVersion="3.0.2" -DhadoopVersion="2.4.0" "run -s EndToEndTests -t \"create an external table with existing data in FS\""
+#      - name: Remove docker containers
+#        run: cd docker && docker-compose down
+#  run-integration-tests-spark-3-1-latest:
+#    runs-on: ubuntu-latest
+#    needs: build
+#    env:
+#      VERTICA_VERSION: 11.0.2-0
+#    steps:
+#      - name: Checkout the project
+#        uses: actions/checkout@v2
+#      - name: Build client image
+#        run: docker build -t client ./docker
+#      - name: Run docker compose
+#        run: cd docker && docker-compose up -d
+#      - name: Create db in Vertica
+#        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
+#      - name: Replace HDFS core-site config with our own
+#        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+#      - name: Replace HDFS hdfs-site config with our own
+#        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+#      - name: Copy partitioned parquet data to HDFS container
+#        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
+#      - name: Copy partitioned parquet data to hadoop from local
+#        uses: nick-invision/retry@v2
+#        with:
+#          timeout_seconds: 20
+#          max_attempts: 10
+#          retry_on: error
+#          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
+#      - name: Download the build artifact
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: build-jar-file
+#          path: ./functional-tests/lib/
+#      - name: Increase active sessions in database
+#        uses: nick-invision/retry@v2
+#        with:
+#          timeout_seconds: 20
+#          max_attempts: 10
+#          retry_on: error
+#          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+#      - name: Copy functional tests to home directory of client container
+#        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
+#      - name: Copy version.properties file from client container
+#        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
+#      - name: Run the integration tests on Spark 3.1
+#        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
+#      - name: Remove docker containers
+#        run: cd docker && docker-compose down
   run-integration-tests-spark-3-2-latest:
     runs-on: ubuntu-latest
     needs: build
@@ -182,6 +182,6 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.2
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="3.2.1" -DhadoopVersion="3.0.1"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="[3.3.0, 3.4.0)"
       - name: Remove docker containers
         run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,6 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.2
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="3.3.0"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="3.3.1"
       - name: Remove docker containers
         run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,8 +141,8 @@ jobs:
   run-integration-tests-spark-3-2-latest:
     runs-on: ubuntu-latest
     needs: build
-#    env:
-#      VERTICA_VERSION: 11.0.2-0
+    env:
+      VERTICA_VERSION: 11.0.2-0
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,6 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.2
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="[3.3.0, 3.4.0)"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="3.2.0" -DhadoopVersion="3.0.1"
       - name: Remove docker containers
         run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.1
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="[3.3.0, 3.4.0)"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="3.3.1"
       - name: Remove docker containers
         run: cd docker && docker-compose down
   run-integration-tests-spark-3-2-latest:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,96 +84,96 @@ jobs:
       - name: Copy version.properties file from client container
         run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
       - name: Run the integration tests on Spark 3.0
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="3.0.2" -DhadoopVersion="2.4.0"
+        run: docker exec -w /home/functional-tests docker_client_1 sbt -DsparkVersion="3.0.2" -DhadoopVersion="2.4.0" "run -s EndToEndTests -t \"create an external table with existing data in FS\""
       - name: Remove docker containers
         run: cd docker && docker-compose down
-  run-integration-tests-spark-3-1-latest:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout the project
-        uses: actions/checkout@v2
-      - name: Build client image
-        run: docker build -t client ./docker
-      - name: Run docker compose
-        run: cd docker && docker-compose up -d
-      - name: Create db in Vertica
-        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
-      - name: Replace HDFS core-site config with our own
-        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
-      - name: Replace HDFS hdfs-site config with our own
-        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-      - name: Copy partitioned parquet data to HDFS container
-        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
-      - name: Copy partitioned parquet data to hadoop from local
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 20
-          max_attempts: 10
-          retry_on: error
-          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
-      - name: Download the build artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-jar-file
-          path: ./functional-tests/lib/
-      - name: Increase active sessions in database
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 20
-          max_attempts: 10
-          retry_on: error
-          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
-      - name: Copy functional tests to home directory of client container
-        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
-      - name: Copy version.properties file from client container
-        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
-      - name: Run the integration tests on Spark 3.1
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
-      - name: Remove docker containers
-        run: cd docker && docker-compose down
-  run-integration-tests-spark-3-2-latest:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout the project
-        uses: actions/checkout@v2
-      - name: Build client image
-        run: docker build -t client ./docker
-      - name: Run docker compose
-        run: cd docker && docker-compose up -d
-      - name: Create db in Vertica
-        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
-      - name: Replace HDFS core-site config with our own
-        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
-      - name: Replace HDFS hdfs-site config with our own
-        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
-      - name: Copy partitioned parquet data to HDFS container
-        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
-      - name: Copy partitioned parquet data to hadoop from local
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 20
-          max_attempts: 10
-          retry_on: error
-          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
-      - name: Download the build artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-jar-file
-          path: ./functional-tests/lib/
-      - name: Increase active sessions in database
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 20
-          max_attempts: 10
-          retry_on: error
-          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
-      - name: Copy functional tests to home directory of client container
-        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
-      - name: Copy version.properties file from client container
-        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
-      - name: Run the integration tests on Spark 3.2
-        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="[3.3.0, 3.4.0)"
-      - name: Remove docker containers
-        run: cd docker && docker-compose down
+#  run-integration-tests-spark-3-1-latest:
+#    runs-on: ubuntu-latest
+#    needs: build
+#    steps:
+#      - name: Checkout the project
+#        uses: actions/checkout@v2
+#      - name: Build client image
+#        run: docker build -t client ./docker
+#      - name: Run docker compose
+#        run: cd docker && docker-compose up -d
+#      - name: Create db in Vertica
+#        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
+#      - name: Replace HDFS core-site config with our own
+#        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+#      - name: Replace HDFS hdfs-site config with our own
+#        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+#      - name: Copy partitioned parquet data to HDFS container
+#        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
+#      - name: Copy partitioned parquet data to hadoop from local
+#        uses: nick-invision/retry@v2
+#        with:
+#          timeout_seconds: 20
+#          max_attempts: 10
+#          retry_on: error
+#          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
+#      - name: Download the build artifact
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: build-jar-file
+#          path: ./functional-tests/lib/
+#      - name: Increase active sessions in database
+#        uses: nick-invision/retry@v2
+#        with:
+#          timeout_seconds: 20
+#          max_attempts: 10
+#          retry_on: error
+#          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+#      - name: Copy functional tests to home directory of client container
+#        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
+#      - name: Copy version.properties file from client container
+#        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
+#      - name: Run the integration tests on Spark 3.1
+#        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.1.0, 3.2.0)" -DhadoopVersion="[3.2.0, 3.3.0)"
+#      - name: Remove docker containers
+#        run: cd docker && docker-compose down
+#  run-integration-tests-spark-3-2-latest:
+#    runs-on: ubuntu-latest
+#    needs: build
+#    steps:
+#      - name: Checkout the project
+#        uses: actions/checkout@v2
+#      - name: Build client image
+#        run: docker build -t client ./docker
+#      - name: Run docker compose
+#        run: cd docker && docker-compose up -d
+#      - name: Create db in Vertica
+#        run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
+#      - name: Replace HDFS core-site config with our own
+#        run: docker exec docker_hdfs_1 cp /hadoop/conf/core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+#      - name: Replace HDFS hdfs-site config with our own
+#        run: docker exec docker_hdfs_1 cp /hadoop/conf/hdfs-site.xml /opt/hadoop/etc/hadoop/hdfs-site.xml
+#      - name: Copy partitioned parquet data to HDFS container
+#        run: docker cp ./functional-tests/src/main/resources/3.1.1 docker_hdfs_1:/partitioned
+#      - name: Copy partitioned parquet data to hadoop from local
+#        uses: nick-invision/retry@v2
+#        with:
+#          timeout_seconds: 20
+#          max_attempts: 10
+#          retry_on: error
+#          command: docker exec docker_hdfs_1 hadoop fs -copyFromLocal /partitioned /3.1.1
+#      - name: Download the build artifact
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: build-jar-file
+#          path: ./functional-tests/lib/
+#      - name: Increase active sessions in database
+#        uses: nick-invision/retry@v2
+#        with:
+#          timeout_seconds: 20
+#          max_attempts: 10
+#          retry_on: error
+#          command: docker exec docker_vertica_1 vsql -c "ALTER DATABASE docker SET MaxClientSessions=100;"
+#      - name: Copy functional tests to home directory of client container
+#        run: docker exec docker_client_1 cp -r /spark-connector/functional-tests /home
+#      - name: Copy version.properties file from client container
+#        run: docker exec docker_client_1 cp -r /spark-connector/version.properties /home
+#      - name: Run the integration tests on Spark 3.2
+#        run: docker exec -w /home/functional-tests docker_client_1 sbt run -DsparkVersion="[3.2.0, 3.3.0)" -DhadoopVersion="[3.3.0, 3.4.0)"
+#      - name: Remove docker containers
+#        run: cd docker && docker-compose down

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose
         run: cd docker && docker-compose up -d
-#      - name: print Vertica version
-#        run: docker exec docker_vertica_1 vsql -c "select version();"
       - name: Create db in Vertica
         run: docker exec docker_vertica_1 /bin/sh -c "opt/vertica/bin/admintools -t create_db --database=docker --password='' --hosts=localhost"
       - name: Replace HDFS core-site config with our own

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -258,6 +258,7 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
 
   }
 
+
   def inferExternalTableSchema(): ConnectorResult[String] = {
     val tableName = config.tablename.getFullTableName.replaceAll("\"","")
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -262,21 +262,18 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
     val tableName = config.tablename.getFullTableName.replaceAll("\"","")
 
     val inferStatement =
-    fileStoreLayer.getGlobStatus(EscapeUtils.sqlEscape(s"${config.fileStoreConfig.externalTableAddress.stripSuffix("/")}/*.parquet")) match {
-      case Right(list) =>
-        val url: String =
-          if(list.nonEmpty) {
-            EscapeUtils.sqlEscape(s"${config.fileStoreConfig.externalTableAddress.stripSuffix("/")}/*.parquet")
-          }
-          else {
-            EscapeUtils.sqlEscape(s"${config.fileStoreConfig.externalTableAddress.stripSuffix("/")}/**/*.parquet")
-          }
-        val query =  "SELECT INFER_EXTERNAL_TABLE_DDL(" + "\'" + url + "\',\'" + tableName + "\')"
-        logger.info(query)
-        query
-
-      case Left(err) => err.getFullContext
-    }
+      fileStoreLayer.getGlobStatus(EscapeUtils.sqlEscape(s"${config.fileStoreConfig.externalTableAddress.stripSuffix("/")}/*.parquet")) match {
+        case Right(list) =>
+          val url: String =
+            if (list.nonEmpty) {
+              EscapeUtils.sqlEscape(s"${config.fileStoreConfig.externalTableAddress.stripSuffix("/")}/*.parquet")
+            }
+            else {
+              EscapeUtils.sqlEscape(s"${config.fileStoreConfig.externalTableAddress.stripSuffix("/")}/**/*.parquet")
+            }
+          "SELECT INFER_EXTERNAL_TABLE_DDL(" + "\'" + url + "\',\'" + tableName + "\')"
+        case Left(err) => err.getFullContext
+      }
 
     logger.debug("The infer statement is: " + inferStatement)
     jdbcLayer.query(inferStatement) match {

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -271,7 +271,9 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
           else {
             EscapeUtils.sqlEscape(s"${config.fileStoreConfig.externalTableAddress.stripSuffix("/")}/**/*.parquet")
           }
-        "SELECT INFER_EXTERNAL_TABLE_DDL(" + "\'" + url + "\',\'" + tableName + "\')"
+        val query =  "SELECT INFER_EXTERNAL_TABLE_DDL(" + "\'" + url + "\',\'" + tableName + "\')"
+        logger.info(query)
+        query
 
       case Left(err) => err.getFullContext
     }

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -965,29 +965,4 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
       })
     }
   }
-
-  it should "error " in {
-    val tname = TableName("testtable", None)
-    val config = createWriteConfig().copy(createExternalTable = Some(NewData), tablename = tname)
-
-    val expectedUrl = config.fileStoreConfig.externalTableAddress + "*.parquet"
-
-    val fileStoreLayerInterface = mock[FileStoreLayerInterface]
-
-    val jdbcLayerInterface = mock[JdbcLayerInterface]
-    (jdbcLayerInterface.commit _).expects().returning(Right(()))
-    (jdbcLayerInterface.close _).expects().returning(Right(()))
-    (jdbcLayerInterface.configureSession _).expects(fileStoreLayerInterface).returning(Right(()))
-
-    val schemaToolsInterface = mock[SchemaToolsInterface]
-
-    val tableUtils = mock[TableUtilsInterface]
-    (tableUtils.createExternalTable _).expects(tname, config.targetTableSql, config.schema, config.strlen, expectedUrl, 0).returning(Right(()))
-    (tableUtils.validateExternalTable _).expects(tname, config.schema).returning(Right(()))
-
-    val pipe = new VerticaDistributedFilesystemWritePipe(config, fileStoreLayerInterface, jdbcLayerInterface, schemaToolsInterface, tableUtils)
-    val inferStmt = pipe.inferExternalTableSchema()
-
-    checkResult(pipe.commit())
-  }
 }

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -58,9 +58,10 @@ object Main extends App {
       val status = if (result.succeeds()) "passed" else "failed"
       println(suite.suiteName + "-- Test run " + status + ": " + reporter.errCount + " error(s) out of " + reporter.testCount + " test cases.")
       reporter
-    } finally {
-      println("IRELIA")
-      sys.exit(1)
+    } catch {
+      case th: Throwable =>
+        println("IRELIA")
+        sys.exit(1)
     }
   }
 

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -277,6 +277,11 @@ object Main extends App {
     sys.exit(exitCode)
   }
 
+  Thread.currentThread().setUncaughtExceptionHandler((t: Thread, th: Throwable) => {
+    println("BRUHHHH")
+    sys.exit(1)
+  })
+
   private def getTestName(options: Options): Option[String] = {
     if (options.testName.isBlank) {
       None

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.scalalogging.Logger
 import com.vertica.spark.config._
 import com.vertica.spark.datasource.core.Disable
 import com.vertica.spark.functests._
@@ -59,8 +60,10 @@ object Main extends App {
       println(suite.suiteName + "-- Test run " + status + ": " + reporter.errCount + " error(s) out of " + reporter.testCount + " test cases.")
       reporter
     } catch {
-      // Got an unexpected exception thrown from tests
-      case _: Throwable =>  sys.exit(1)
+      case e: Throwable =>
+        Logger(Main.getClass).error("Uncaught exception from tests: " + e.getMessage)
+        e.printStackTrace()
+        sys.exit(1)
     }
   }
 

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -277,11 +277,6 @@ object Main extends App {
     sys.exit(exitCode)
   }
 
-  Thread.currentThread().setUncaughtExceptionHandler((t: Thread, th: Throwable) => {
-    println("BRUHHHH")
-    sys.exit(1)
-  })
-
   private def getTestName(options: Options): Option[String] = {
     if (options.testName.isBlank) {
       None

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -59,9 +59,8 @@ object Main extends App {
       println(suite.suiteName + "-- Test run " + status + ": " + reporter.errCount + " error(s) out of " + reporter.testCount + " test cases.")
       reporter
     } catch {
-      case th: Throwable =>
-        println("IRELIA")
-        sys.exit(1)
+      // Got an unexpected exception thrown from tests
+      case _: Throwable =>  sys.exit(1)
     }
   }
 

--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -53,10 +53,15 @@ case class TestSuiteFailed(tests: List[TestFailed] = List(), failedCount: Int, t
 object Main extends App {
   def runSuite(suite: TestSuite, testName: Option[String] = None): VReporter = {
     val reporter = VReporter(suite.suiteName)
-    val result = suite.run(testName, Args(reporter))
-    val status = if (result.succeeds()) "passed" else "failed"
-    println(suite.suiteName + "-- Test run "+ status +": " + reporter.errCount + " error(s) out of " + reporter.testCount + " test cases.")
-    reporter
+    try {
+      val result = suite.run(testName, Args(reporter))
+      val status = if (result.succeeds()) "passed" else "failed"
+      println(suite.suiteName + "-- Test run " + status + ": " + reporter.errCount + " error(s) out of " + reporter.testCount + " test cases.")
+      reporter
+    } finally {
+      println("IRELIA")
+      sys.exit(1)
+    }
   }
 
   val conf: Config = ConfigFactory.load()

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
@@ -27,8 +27,6 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 import org.scalatest.BeforeAndAfterAll
 
-import java.lang.Thread.UncaughtExceptionHandler
-
 /**
  * Tests basic functionality of the VerticaHDFSLayer
  *

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
@@ -37,11 +37,6 @@ import java.lang.Thread.UncaughtExceptionHandler
 
 class HDFSTests(val fsCfg: FileStoreConfig, val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfterAll {
 
-  Thread.currentThread().setUncaughtExceptionHandler((t: Thread, th: Throwable) => {
-    println("BRUHHHH")
-    sys.exit(1)
-  })
-
   private lazy val (spark, fsLayer, dirTestCfg, df) = {
     val spark = SparkSession.builder()
       .master("local[*]")

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/HDFSTests.scala
@@ -14,7 +14,6 @@
 package com.vertica.spark.functests
 
 import java.sql.Connection
-
 import com.vertica.spark.config.{FileStoreConfig, JDBCConfig}
 import org.scalatest.flatspec.AnyFlatSpec
 import com.vertica.spark.datasource.core.{DataBlock, ParquetFileRange}
@@ -28,6 +27,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 import org.scalatest.BeforeAndAfterAll
 
+import java.lang.Thread.UncaughtExceptionHandler
+
 /**
  * Tests basic functionality of the VerticaHDFSLayer
  *
@@ -35,6 +36,11 @@ import org.scalatest.BeforeAndAfterAll
  */
 
 class HDFSTests(val fsCfg: FileStoreConfig, val jdbcCfg: JDBCConfig) extends AnyFlatSpec with BeforeAndAfterAll {
+
+  Thread.currentThread().setUncaughtExceptionHandler((t: Thread, th: Throwable) => {
+    println("BRUHHHH")
+    sys.exit(1)
+  })
 
   private lazy val (spark, fsLayer, dirTestCfg, df) = {
     val spark = SparkSession.builder()

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/ComplexTypeTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/ComplexTypeTests.scala
@@ -366,16 +366,21 @@ class ComplexTypeTests(readOpts: Map[String, String], writeOpts: Map[String, Str
   }
 
   it should "write external table with Vertica map" in {
-    val tableName = "dftest"
+    val tableName = "dftest-map"
     val schema = new StructType(Array(
       StructField("col1", MapType(IntegerType, IntegerType)),
       StructField("col2", IntegerType)
     ))
-    val data = Seq(Row(Map()+(77 -> 88), 55))
+    val data = Seq(
+      Row(
+        Map(77 -> 88),
+        55)
+    )
 
     val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
     val mode = SaveMode.Overwrite
-    val options = writeOpts + ("table" -> tableName, "create_external_table" -> "true", "staging_fs_url" -> (fsConfig.address +"dftest"))
+    val externalDataPath = fsConfig.address + tableName
+    val options = writeOpts + ("table" -> tableName, "create_external_table" -> "true", "staging_fs_url" -> externalDataPath)
 
     val result = Try {
       df.write.format(VERTICA_SOURCE)
@@ -383,9 +388,13 @@ class ComplexTypeTests(readOpts: Map[String, String], writeOpts: Map[String, Str
         .mode(mode)
         .save()
 
-      val rs = conn.createStatement().executeQuery("select \"col2\" from dftest;")
-      rs.next()
-      assert(rs.getInt(1) == 55)
+      val stmt = conn.createStatement()
+      val rs = stmt.executeQuery(s"select * from tables where table_name='$tableName' and table_schema='public'")
+      assert(rs.next)
+      val tableDefinition = rs.getString("table_definition")
+      val expected = s"COPY FROM '$externalDataPath/*.parquet' PARQUET"
+      assert(tableDefinition.trim() == expected)
+      assert(!rs.next)
     }
 
     TestUtils.dropTable(conn, tableName)


### PR DESCRIPTION
### Summary

Fixed issues with functional tests failing on S3. Vertica 11.1 and Hadoop 3.3.1.

### Changes
 * Main now runs against Vertica 11.0.2-0 until support is implemented for Vertica 11.1
 * Spark 3.2 test will use Hadoop 3.3.1 
 * Fix a functional tests to authenticate jdbc using VerticaJdbcLayer

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
@jeremyp-bq 
@jonathanl-bq 
