### PR TITLE
Vertica 11.1 INFER_TABLE_DDL support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     env:
-      VERTICA_VERSION: 11.0.2-0
+      VERTICA_VERSION: 11.1.1-0
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     env:
-      VERTICA_VERSION: 11.0.2-0
+      VERTICA_VERSION: 11.1.1-0
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     env:
-      VERTICA_VERSION: 11.0.2-0
+      VERTICA_VERSION: 11.1.1-0
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -577,15 +577,15 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
 }
 
 /**
- * With changes made in Vertica 11.1, this class contains old implmentation to support previous Vertica versions.
+ * With changes made in Vertica 11.1, this class contains implmentation to support previous Vertica versions.
  *
  * */
-class VerticaDistributedFilesystemWritePipeOld(override val config: DistributedFilesystemWriteConfig,
-                                               override val fileStoreLayer: FileStoreLayerInterface,
-                                               override val jdbcLayer: JdbcLayerInterface,
-                                               override val schemaTools: SchemaToolsInterface,
-                                               override val tableUtils: TableUtilsInterface,
-                                               override val dataSize: Int = 1)
+class VerticaDistributedFilesystemWritePipeLegacy(override val config: DistributedFilesystemWriteConfig,
+                                                  override val fileStoreLayer: FileStoreLayerInterface,
+                                                  override val jdbcLayer: JdbcLayerInterface,
+                                                  override val schemaTools: SchemaToolsInterface,
+                                                  override val tableUtils: TableUtilsInterface,
+                                                  override val dataSize: Int = 1)
   extends VerticaDistributedFilesystemWritePipe(config, fileStoreLayer, jdbcLayer, schemaTools, tableUtils, dataSize){
 
   override protected def buildInferStatement(url: String, tableName: String): String =

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -280,8 +280,8 @@ class VerticaDistributedFilesystemWritePipe(val config: DistributedFilesystemWri
       case Left(err) => Left(InferExternalTableSchemaError(err))
       case Right(resultSet) =>
         try {
-          val iterate = resultSet.next
-          val createExternalTableStatement = resultSet.getString("INFER_EXTERNAL_TABLE_DDL")
+          resultSet.next
+          val createExternalTableStatement = resultSet.getString(1)
           val isPartitioned = inferStatement.contains(EscapeUtils.sqlEscape(s"${config.fileStoreConfig.externalTableAddress.stripSuffix("/")}/**/*.parquet"))
 
           if(!isPartitioned && !createExternalTableStatement.contains("varchar") && !createExternalTableStatement.contains("varbinary")) {

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -14,7 +14,6 @@
 package com.vertica.spark.datasource.core
 
 import com.vertica.spark.config._
-import com.vertica.spark.datasource.core.factory.VerticaPipeFactory.readLayer
 import com.vertica.spark.datasource.fs.FileStoreLayerInterface
 import com.vertica.spark.datasource.jdbc.{JdbcLayerInterface, JdbcUtils}
 import com.vertica.spark.util.Timer
@@ -24,9 +23,8 @@ import com.vertica.spark.util.error.CreateExternalTableAlreadyExistsError
 import com.vertica.spark.util.error._
 import com.vertica.spark.util.schema.SchemaToolsInterface
 import com.vertica.spark.util.table.TableUtilsInterface
-import com.vertica.spark.util.version.{VerticaVersion, VerticaVersionUtils}
+import com.vertica.spark.util.version.VerticaVersionUtils
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
 import scala.util.Try

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
@@ -96,6 +96,7 @@ object VerticaPipeFactory extends VerticaPipeFactoryInterface {
         writeLayerJdbc = checkJdbcLayer(writeLayerJdbc, cfg.jdbcConfig)
         val verticaVersion = VerticaVersionUtils.getVersion(writeLayerJdbc.get)
         val schemaTools = if (verticaVersion.major == 10) new SchemaToolsV10 else new SchemaTools
+        //scalastyle:off
         if(verticaVersion.largerOrEqual(VerticaVersion(11,1))){
           new VerticaDistributedFilesystemWritePipe(cfg,
             new HadoopFileStoreLayer(cfg.fileStoreConfig, Some(cfg.schema)),

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
@@ -105,7 +105,7 @@ object VerticaPipeFactory extends VerticaPipeFactoryInterface {
             new TableUtils(schemaTools, writeLayerJdbc.get)
           )
         } else {
-          new VerticaDistributedFilesystemWritePipeOld(cfg,
+          new VerticaDistributedFilesystemWritePipeLegacy(cfg,
             new HadoopFileStoreLayer(cfg.fileStoreConfig, Some(cfg.schema)),
             writeLayerJdbc.get,
             schemaTools,

--- a/connector/src/main/scala/com/vertica/spark/util/version/VerticaVersion.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/version/VerticaVersion.scala
@@ -99,6 +99,11 @@ object VerticaVersionUtils {
 }
 
 case class VerticaVersion(major: Int, minor: Int = 0, servicePack: Int = 0, hotfix: Int = 0) extends Ordered[VerticaVersion] {
+
+  def largerOrEqual(version: VerticaVersion): Boolean = this.compare(version) >= 0
+
+  def lesserOrEqual(version: VerticaVersion): Boolean = this.compare(version) <= 0
+
   override def toString: String = s"${major}.${minor}.${servicePack}-${hotfix}"
 
   override def compare(that: VerticaVersion): Int =

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -752,7 +752,7 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
     (tableUtils.createExternalTable _).expects(tname, Some(createExternalTableStmt), config.schema, config.strlen, url, 0).returning(Right(()))
     (tableUtils.validateExternalTable _).expects(tname, config.schema).returning(Right(()))
 
-    val pipe = new VerticaDistributedFilesystemWritePipeOld(config, fileStoreLayerInterface, jdbcLayerInterface, schemaToolsInterface, tableUtils)
+    val pipe = new VerticaDistributedFilesystemWritePipeLegacy(config, fileStoreLayerInterface, jdbcLayerInterface, schemaToolsInterface, tableUtils)
 
     checkResult(pipe.commit())
   }

--- a/connector/src/test/scala/com/vertica/spark/util/version/VerticaVersionUtilsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/version/VerticaVersionUtilsTest.scala
@@ -183,3 +183,16 @@ class VerticaVersionUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with Mo
     }
   }
 }
+
+class VerticaVersionTest extends AnyFlatSpec with BeforeAndAfterAll with MockFactory with org.scalatest.OneInstancePerTest {
+
+  it should "compare to bigger Vertica version" in {
+    assert(VerticaVersion(11,1,5,3).largerOrEqual(VerticaVersion(10,4,7,5)))
+  }
+
+  it should "compare to smaller Vertica version" in {
+    assert(VerticaVersion(11,1,5,3).largerOrEqual(VerticaVersion(12,0,2,1)))
+  }
+}
+
+

--- a/connector/src/test/scala/com/vertica/spark/util/version/VerticaVersionUtilsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/version/VerticaVersionUtilsTest.scala
@@ -186,13 +186,13 @@ class VerticaVersionUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with Mo
 
 class VerticaVersionTest extends AnyFlatSpec with BeforeAndAfterAll with MockFactory with org.scalatest.OneInstancePerTest {
 
-  //scalastyle:off
   it should "compare to bigger Vertica version" in {
+    //scalastyle:off
     assert(VerticaVersion(11,1,5,3).largerOrEqual(VerticaVersion(10,4,7,5)))
   }
 
-  //scalastyle:off
   it should "compare to smaller Vertica version" in {
+    //scalastyle:off
     assert(VerticaVersion(11,1,5,3).lesserOrEqual(VerticaVersion(12,0,2,1)))
   }
 }

--- a/connector/src/test/scala/com/vertica/spark/util/version/VerticaVersionUtilsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/version/VerticaVersionUtilsTest.scala
@@ -186,12 +186,14 @@ class VerticaVersionUtilsTest extends AnyFlatSpec with BeforeAndAfterAll with Mo
 
 class VerticaVersionTest extends AnyFlatSpec with BeforeAndAfterAll with MockFactory with org.scalatest.OneInstancePerTest {
 
+  //scalastyle:off
   it should "compare to bigger Vertica version" in {
     assert(VerticaVersion(11,1,5,3).largerOrEqual(VerticaVersion(10,4,7,5)))
   }
 
+  //scalastyle:off
   it should "compare to smaller Vertica version" in {
-    assert(VerticaVersion(11,1,5,3).largerOrEqual(VerticaVersion(12,0,2,1)))
+    assert(VerticaVersion(11,1,5,3).lesserOrEqual(VerticaVersion(12,0,2,1)))
   }
 }
 


### PR DESCRIPTION
### Summary

Vertica 11.1 deprecated `INFER_EXTERNAL_TABLE_DDL`. This change adds support to the new `INFER_TABLE_DDL`

### Related Issue

Closes #391 

### Additional Reviewers
@alexr-bq 
@jeremyp-bq 
@jonathanl-bq 
