### PR TITLE
Fix issues with execution of remote tests

### DIFF
--- a/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/RemoteTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/RemoteTests.scala
@@ -68,9 +68,9 @@ class RemoteTests(readOpts: Map[String, String], writeOpts: Map[String, String],
     } catch {
       case exception: Exception => fail("Unexpected exception", exception)
     } finally {
+      stmt.execute("drop table dftest;")
       stmt.close()
     }
-    stmt.execute("drop table dftest;")
   }
 
 }

--- a/functional-tests/submit-functional-tests.sh
+++ b/functional-tests/submit-functional-tests.sh
@@ -5,4 +5,4 @@ export SPARK_HOME=/opt/spark
 export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin
 start-master.sh -h localhost
 start-worker.sh -h localhost spark://localhost:7077
-spark-submit --master spark://localhost:7077 target/scala-2.12/spark-vertica-connector-functional-tests-assembly-$CONNECTOR_VERSION.jar $1
+spark-submit --master spark://localhost:7077 --driver-memory 2g target/scala-2.12/spark-vertica-connector-functional-tests-assembly-$CONNECTOR_VERSION.jar $1


### PR DESCRIPTION
### Summary

Was unable to run the tests with the default 1g of driver memory, and the test failed since it tried to use a closed statement.

### Additional Reviewers

@alexey-temnikov
@alexr-bq
@Aryex
@jonathanl-bq
