### PR TITLE
Refactor parquet partitioning and reading

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -119,63 +119,71 @@ class VerticaDistributedFilesystemReadPipe(
     map(filename) - 1
   }
 
-  private def getPartitionInfo(fileMetadata: Seq[ParquetFileMetadata], partitionCount: Int): PartitionInfo = {
+  /**
+   * A partition contains a collection of Parquet row groups.
+   * The number of partitions = total parquet row groups / partitionCount.
+   *
+   * @param fileMetadata A list of parquet metadata
+   *
+   * @param requestedPartitionCount the number of partition to create
+   * */
+  private def getPartitionInfo(fileMetadata: Seq[ParquetFileMetadata], requestedPartitionCount: Int): PartitionInfo = {
     val totalRowGroups = fileMetadata.map(_.rowGroupCount).sum
 
     // If no data, return empty partition list
     if(totalRowGroups == 0) {
       logger.info("No data. Returning empty partition list.")
       PartitionInfo(Array[InputPartition]())
-    }
-    else {
-      val extraSpace = if(totalRowGroups % partitionCount == 0) 0 else 1
-      val rowGroupRoom = (totalRowGroups / partitionCount) + extraSpace
-
-      // Now, create partitions splitting up files roughly evenly
-      var i = 0
+    } else {
       var partitions = List[VerticaDistributedFilesystemPartition]()
-      var curFileRanges = List[ParquetFileRange]()
+      var fileRanges = List[ParquetFileRange]()
       val rangeCountMap = scala.collection.mutable.Map[String, Int]()
 
       logger.info("Creating partitions.")
-      for(m <- fileMetadata) {
-        val size = m.rowGroupCount
-        logger.debug("Splitting file " + m.filename + " with row group count " + size)
-        var j = 0
-        var low = 0
-        while(j < size){
-          if(i == rowGroupRoom-1){ // Reached end of partition, cut off here
-            val rangeIdx = incrementRangeMapGetIndex(rangeCountMap, m.filename)
 
-            val frange = ParquetFileRange(m.filename, low, j, Some(rangeIdx))
+      val extraSpace = if(totalRowGroups % requestedPartitionCount == 0) 0 else 1
+      val maxSize = (totalRowGroups / requestedPartitionCount) + extraSpace
+      // The row group count of a partition
+      var partitionSize = 0
+      // Create partitions by splitting up files roughly evenly
+      fileMetadata.foreach(metadata => {
+        val fileRowGroupCount = metadata.rowGroupCount
+        var start = 0
 
-            curFileRanges = curFileRanges :+ frange
-            val partition = VerticaDistributedFilesystemPartition(curFileRanges)
-            partitions = partitions :+ partition
-            curFileRanges = List[ParquetFileRange]()
-            logger.debug("Reached partition with file " + m.filename + " , range low: " +
-              low + " , range high: " + j + " , idx: " + rangeIdx)
-            i = 0
-            low = j + 1
-          }
-          else if(j == size - 1){ // Reached end of file's row groups, add to file ranges
-            val rangeIdx = incrementRangeMapGetIndex(rangeCountMap, m.filename)
-            val frange = ParquetFileRange(m.filename, low, j, Some(rangeIdx))
-            curFileRanges = curFileRanges :+ frange
-            logger.debug("Reached end of file " + m.filename + " , range low: " +
-              low + " , range high: " + j + " , idx: " + rangeIdx)
-            i += 1
-          }
-          else {
-            i += 1
-          }
-          j += 1
+        def addNewPartition(currRowGroup: Int): Unit = {
+          val rangeIdx = incrementRangeMapGetIndex(rangeCountMap, metadata.filename)
+          fileRanges = fileRanges :+ ParquetFileRange(metadata.filename, start, currRowGroup, Some(rangeIdx))
+          partitions = partitions :+ VerticaDistributedFilesystemPartition(fileRanges)
+          logger.debug("Reached partition with file " + metadata.filename + " , range low: " +
+            start + " , range high: " + currRowGroup + " , idx: " + rangeIdx)
+          partitionSize = 0
+          start = currRowGroup + 1
+          fileRanges = List[ParquetFileRange]()
         }
-      }
+
+        def addNewFileRange(currRowGroup: Int): Unit = {
+          val rangeIdx = incrementRangeMapGetIndex(rangeCountMap, metadata.filename)
+          val frange = ParquetFileRange(metadata.filename, start, currRowGroup, Some(rangeIdx))
+          fileRanges = fileRanges :+ frange
+          logger.debug("Reached end of file " + metadata.filename + " , range low: " +
+            start + " , range high: " + currRowGroup + " , idx: " + rangeIdx)
+          partitionSize += 1
+        }
+
+        (0 until fileRowGroupCount).foreach(currRowGroup => {
+          if(partitionSize == maxSize - 1) {
+            addNewPartition(currRowGroup)
+          } else if (partitionSize == fileRowGroupCount - 1) {
+            addNewFileRange(currRowGroup)
+          } else {
+            partitionSize += 1
+          }
+        })
+      })
 
       // Last partition if leftover (only partition not of rowGroupRoom size)
-      if(curFileRanges.nonEmpty) {
-        val partition = VerticaDistributedFilesystemPartition(curFileRanges)
+      if(fileRanges.nonEmpty) {
+        val partition = VerticaDistributedFilesystemPartition(fileRanges)
         partitions = partitions :+ partition
       }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemReadPipe.scala
@@ -173,7 +173,7 @@ class VerticaDistributedFilesystemReadPipe(
         (0 until fileRowGroupCount).foreach(currRowGroup => {
           if(partitionSize == maxSize - 1) {
             addNewPartition(currRowGroup)
-          } else if (partitionSize == fileRowGroupCount - 1) {
+          } else if (currRowGroup == fileRowGroupCount - 1) {
             addNewFileRange(currRowGroup)
           } else {
             partitionSize += 1

--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -80,6 +80,9 @@ trait FileStoreLayerInterface {
   def getGCSOptions: GCSOptions
 }
 
+/**
+ * A Parquet reader that reads each row into a Spark [[InternalRow]]
+ * */
 final case class HadoopFileStoreReader(reader: ParquetFileReader, columnIO: MessageColumnIO, recordConverter: RecordMaterializer[InternalRow], fileRange: ParquetFileRange) {
 
   private var curRowGroup = fileRange.minRowGroup
@@ -100,7 +103,7 @@ final case class HadoopFileStoreReader(reader: ParquetFileReader, columnIO: Mess
           Some(columnIO.getRecordReader(pages, recordConverter, FilterCompat.NOOP))
         case None => None
       }
-    } else None
+    } else {None}
   }
 
   private def checkRowGroup(): Option[RecordReader[InternalRow]] = {

--- a/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/fs/FileStoreLayerInterface.scala
@@ -81,56 +81,52 @@ trait FileStoreLayerInterface {
 }
 
 final case class HadoopFileStoreReader(reader: ParquetFileReader, columnIO: MessageColumnIO, recordConverter: RecordMaterializer[InternalRow], fileRange: ParquetFileRange) {
-  private var recordReader: Option[RecordReader[InternalRow]] = None
-  private var curRow = 0L
+
+  private var curRowGroup = fileRange.minRowGroup
+  // Move reader to position
+  (0 until fileRange.minRowGroup).foreach(_ => reader.skipNextRowGroup)
+
+  private var currRow = 0L
   private var rowCount = 0L
-  private var curRowGroup = 0L
+  private var currRecordReader: Option[RecordReader[InternalRow]] = nextRecordReader
 
-  private def doneReading() : Unit = {
-    this.recordReader = None
-    rowCount = -1
-  }
-
-  def checkUpdateRecordReader(): Unit = {
-    if(this.curRow == this.rowCount){
-      while(this.curRowGroup < fileRange.minRowGroup) {
-        reader.skipNextRowGroup()
-        this.curRowGroup += 1
-      }
-
-      if(this.curRowGroup > fileRange.maxRowGroup) {
-        this.doneReading()
-      }
-      else {
-        val pages = reader.readNextRowGroup()
-        if(pages != null) {
-          this.recordReader = Some(columnIO.getRecordReader(pages, recordConverter, FilterCompat.NOOP))
+  private def nextRecordReader: Option[RecordReader[InternalRow]] = {
+    if (this.curRowGroup <= fileRange.maxRowGroup) {
+      Option(reader.readNextRowGroup()) match {
+        case Some(pages) =>
           this.rowCount = pages.getRowCount
-          this.curRow = 0
+          this.currRow = 0
           this.curRowGroup += 1
-        }
-        else {
-          this.doneReading()
-        }
+          Some(columnIO.getRecordReader(pages, recordConverter, FilterCompat.NOOP))
+        case None => None
       }
-    }
-
-    this.curRow += 1
-
+    } else None
   }
 
-  def read(blockSize: Int) : ConnectorResult[DataBlock] = {
-    (0 until blockSize).map(_ => Try {
-      this.checkUpdateRecordReader()
-      recordReader match {
+  private def checkRowGroup(): Option[RecordReader[InternalRow]] = {
+    if (this.currRow == this.rowCount) {
+      this.currRecordReader = nextRecordReader
+    }
+    this.currRow += 1
+    this.currRecordReader
+  }
+
+  private def readRow: Either[ConnectorError, Option[InternalRow]] = {
+    Try {
+      this.checkRowGroup() match {
+        case Some(reader) =>
+          Some(reader.read().copy())
         case None => None
-        case Some(reader) => Some(reader.read().copy())
       }
     } match {
       case Failure(exception) => Left(IntermediaryStoreReadError(exception)
         .context("Error reading parquet file from HDFS."))
       case Success(v) => Right(v)
-    }).toList.sequence match {
+    }
+  }
+
+  def read(blockSize: Int) : ConnectorResult[DataBlock] = {
+    (0 until blockSize).map(_ => readRow).toList.sequence match {
       case Left(err) => Left(err)
       case Right(list) => Right(DataBlock(list.flatten))
     }


### PR DESCRIPTION
### Summary

Code for partitioning parquet files and reading were refactored. Changes were made only for increased readability, underlying functionalities and logics should stay the same.

### What was refactored

ReadPipe's getPartitionInfo() 
HadoopFileStoreReader()

### Additional Reviewers
@alexey-temnikov 
@alexr-bq 
@jeremyp-bq 
@jonathanl-bq 
