### PR TITLE
Updated Spark to 3.2.1

### DIFF
--- a/connector/build.sbt
+++ b/connector/build.sbt
@@ -30,8 +30,8 @@ resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
 libraryDependencies += "com.vertica.jdbc" % "vertica-jdbc" % "11.0.2-0"
-libraryDependencies += "org.apache.spark" %% "spark-core" % "latest.release"
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "latest.release"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "3.2.1"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.2.1"
 libraryDependencies += "org.apache.hadoop" % "hadoop-hdfs" % "3.3.0"
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.2" % Test
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.2" % "test"

--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -26,7 +26,7 @@ organization := "com.vertica"
 version := versionProps.value.getProperty("connector-version")
 
 val sparkVersion = Option(System.getProperty("sparkVersion")).getOrElse("3.2.1")
-val hadoopVersion = Option(System.getProperty("hadoopVersion")).getOrElse("3.1.1")
+val hadoopVersion = Option(System.getProperty("hadoopVersion")).getOrElse("3.3.0")
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
 resolvers += "jitpack" at "https://jitpack.io"

--- a/functional-tests/build.sbt
+++ b/functional-tests/build.sbt
@@ -25,7 +25,7 @@ name := "spark-vertica-connector-functional-tests"
 organization := "com.vertica"
 version := versionProps.value.getProperty("connector-version")
 
-val sparkVersion = Option(System.getProperty("sparkVersion")).getOrElse("3.2.0")
+val sparkVersion = Option(System.getProperty("sparkVersion")).getOrElse("3.2.1")
 val hadoopVersion = Option(System.getProperty("hadoopVersion")).getOrElse("3.1.1")
 
 resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"


### PR DESCRIPTION
### Summary
Updated build to use spark version 3.2.1 instead of using the latest version.