### PR TITLE
Fix failing create table statement with empty row field names

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipe.scala
@@ -17,10 +17,8 @@ import com.vertica.spark.config._
 import com.vertica.spark.datasource.fs.FileStoreLayerInterface
 import com.vertica.spark.datasource.jdbc.{JdbcLayerInterface, JdbcUtils}
 import com.vertica.spark.util.Timer
-import com.vertica.spark.util.error.CreateExternalTableMergeKey
-import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
-import com.vertica.spark.util.error.CreateExternalTableAlreadyExistsError
 import com.vertica.spark.util.error._
+import com.vertica.spark.util.error.ErrorHandling.ConnectorResult
 import com.vertica.spark.util.schema.SchemaToolsInterface
 import com.vertica.spark.util.table.TableUtilsInterface
 import com.vertica.spark.util.version.VerticaVersionUtils

--- a/connector/src/main/scala/com/vertica/spark/util/error/ErrorHandling.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/error/ErrorHandling.scala
@@ -640,4 +640,8 @@ case class ExportToJsonNotSupported(version: String) extends ConnectorError {
     "Export to JSON is required for reading complex data types."
 }
 
+case class BlankColumnNamesError() extends SchemaError {
+  override def getFullContext: String = "Column names cannot contains only white spaces or be empty"
+}
+
 

--- a/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
@@ -512,7 +512,13 @@ class SchemaTools(ctTools: ComplexTypesSchemaTools = new ComplexTypesSchemaTools
 
   def makeTableColumnDefs(schema: StructType, strlen: Long, arrayLength: Long): ConnectorResult[String] = {
     val colDefsOrErrors = schema.map(col => {
-      val colName = "\"" + col.name + "\""
+
+      val colName = if(col.name.isEmpty){
+        ""
+      } else {
+        "\"" + col.name + "\""
+      }
+
       val notNull = if (!col.nullable) "NOT NULL" else ""
       getVerticaTypeFromSparkType(col.dataType, strlen, arrayLength, col.metadata) match {
         case Left(err) => Left(SchemaConversionError(err).context("Schema error when trying to create table"))

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -1148,7 +1148,17 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
     }
   }
 
-  it should "build create row column def string with empty field name" in {
+  it should "build column def string with empty column name containing no quotations" in {
+    val schema = StructType(Array(StructField("", IntegerType)))
+
+    new SchemaTools().makeTableColumnDefs(schema, 0, 0) match {
+      case Left(e) => fail("Expected to succeed")
+      case Right(str) =>
+        assert(str == " (INTEGER)")
+    }
+  }
+
+  it should "build row column def with empty field name" in {
     val schema = StructType(Array(
       StructField("col1", StructType(Array(
         StructField("", IntegerType),
@@ -1164,7 +1174,7 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
     }
   }
 
-  it should "error on empty names" in {
+  it should "error on empty column name" in {
     val schema = StructType(Array(
       StructField("col1", StructType(Array(
         StructField("", IntegerType),

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -1163,6 +1163,36 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
         assert(str == " (\"col1\" ROW(INTEGER, VARCHAR(0), \"cat\" INTEGER))")
     }
   }
+
+  it should "error on empty names" in {
+    val schema = StructType(Array(
+      StructField("col1", StructType(Array(
+        StructField("", IntegerType),
+        StructField("cat", IntegerType),
+      ))),
+      StructField("", StringType)
+    ))
+
+    new SchemaTools().checkValidTableSchema(schema) match {
+      case Left(exp) => assert(exp.isInstanceOf[BlankColumnNamesError])
+      case Right(_) => fail("expected to fail")
+    }
+  }
+
+  it should "error on names with only white space" in {
+    val schema = StructType(Array(
+      StructField("col1", StructType(Array(
+        StructField("", IntegerType),
+        StructField("cat", IntegerType),
+      ))),
+      StructField("   ", StringType)
+    ))
+
+    new SchemaTools().checkValidTableSchema(schema) match {
+      case Left(exp) => assert(exp.isInstanceOf[BlankColumnNamesError])
+      case Right(_) => fail("expected to fail")
+    }
+  }
 }
 // For package private access without instantiation
 object SchemaToolsTests extends SchemaToolsTests

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -1147,6 +1147,22 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
       }
     }
   }
+
+  it should "build create row column def string with empty field name" in {
+    val schema = StructType(Array(
+      StructField("col1", StructType(Array(
+        StructField("", IntegerType),
+        StructField("", StringType),
+        StructField("cat", IntegerType),
+      )))
+    ))
+
+    new SchemaTools().makeTableColumnDefs(schema, 0, 0) match {
+      case Left(e) => fail("Expected to succeed")
+      case Right(str) =>
+        assert(str == " (\"col1\" ROW(INTEGER, VARCHAR(0), \"cat\" INTEGER))")
+    }
+  }
 }
 // For package private access without instantiation
 object SchemaToolsTests extends SchemaToolsTests

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/ComplexTypeTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/ComplexTypeTests.scala
@@ -722,28 +722,21 @@ class ComplexTypeTests(readOpts: Map[String, String], writeOpts: Map[String, Str
     val tableName = "dftest"
     val colName = "col1"
     val schema = new StructType(Array(
-      StructField("required", IntegerType),
+      StructField("    ", IntegerType),
       StructField(colName, StructType(Array(
         StructField("", IntegerType, false, Metadata.empty)
       )))))
 
     val data = Seq(Row(1,Row(77)))
     val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
-    println(df.toString())
-    val mode = SaveMode.Overwrite
-
-    val stmt = conn.createStatement()
     try {
       df.write.format("com.vertica.spark.datasource.VerticaSource")
         .options(writeOpts + ("table" -> tableName))
-        .mode(mode)
+        .mode(SaveMode.Overwrite)
         .save()
     }
     catch{
       case err : Exception => fail(err)
-    }
-    finally {
-      stmt.close()
     }
 
     TestUtils.dropTable(conn, tableName)

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/ComplexTypeTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/ComplexTypeTests.scala
@@ -722,7 +722,7 @@ class ComplexTypeTests(readOpts: Map[String, String], writeOpts: Map[String, Str
     val tableName = "dftest"
     val colName = "col1"
     val schema = new StructType(Array(
-      StructField("    ", IntegerType),
+      StructField("required", IntegerType),
       StructField(colName, StructType(Array(
         StructField("", IntegerType, false, Metadata.empty)
       )))))

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/EndToEndTests.scala
@@ -4142,5 +4142,27 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     TestUtils.dropTable(conn, tableName)
   }
 
+
+  it should "error on empty column names" in {
+    val tableName = "dftest"
+    val schema = new StructType(Array(StructField("", IntegerType)))
+    val data = Seq(Row(1,Row(77)))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+    try {
+      df.write.format("com.vertica.spark.datasource.VerticaSource")
+        .options(writeOpts + ("table" -> tableName))
+        .mode(SaveMode.Overwrite)
+        .save()
+    }
+    catch{
+      case ConnectorException(error) => error match {
+        case BlankColumnNamesError() => succeed
+        case _ => fail
+      }
+    }
+
+    TestUtils.dropTable(conn, tableName)
+  }
+
 }
 


### PR DESCRIPTION
### Summary

Updated `SchemaTools.makeTableColumnDefs` to not contains empty double-quotes when column name is empty.
Also added connector error for when column names are blank.

Related tests are updated.

### Related Issue

Closes #443 

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
@jeremyp-bq 
@jonathanl-bq 
