### PR TITLE
Support query option schema

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/config/TableName.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/TableName.scala
@@ -13,8 +13,6 @@
 
 package com.vertica.spark.config
 
-import com.vertica.spark.datasource.core.SessionId
-
 object EscapeUtils {
   def sqlEscape(str: String, char: Char = '\"'): String = {
     val c = char.toString
@@ -72,7 +70,7 @@ final case class TableName(name: String, dbschema: Option[String]) extends Table
   override def identifier: String = name
 }
 
-final case class TableQuery(query: String, uniqueId: String) extends TableSource {
+final case class TableQuery(query: String, uniqueId: String, dbSchema: Option[String]) extends TableSource {
   override def identifier: String = uniqueId
 }
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
@@ -600,7 +600,8 @@ object DSConfigSetupUtils {
     val query = DSConfigSetupUtils.getQuery(config)
 
     (query, name) match {
-      case (Some(q), _) => TableQuery(q, SessionId.getId).validNec
+      case (Some(q), _) => TableQuery(q, SessionId.getId, schema).validNec
+      case (Some(q), None) => TableQuery(q, SessionId.getId, schema).validNec
       case (None, Some(n)) => TableName(n, schema).validNec
       case (None, None) => TableAndQueryMissingError().invalidNec
     }

--- a/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
@@ -267,7 +267,7 @@ class SchemaTools(ctTools: ComplexTypesSchemaTools = new ComplexTypesSchemaTools
   def getColumnInfo(jdbcLayer: JdbcLayerInterface, tableSource: TableSource): ConnectorResult[Seq[ColumnDef]] = {
     val emptyQuery = tableSource match {
       case tb: TableName => "SELECT * FROM " + tb.getFullTableName + " WHERE 1=0"
-      case TableQuery(query, _) => "SELECT * FROM (" + query + ") AS x WHERE 1=0"
+      case TableQuery(query, _, _) => "SELECT * FROM (" + query + ") AS x WHERE 1=0"
     }
    // We query an empty result to get the table's metadata.
     jdbcLayer.query(emptyQuery) match {
@@ -665,7 +665,7 @@ class SchemaToolsV10 extends SchemaTools {
               val unQuotedName = tb.getTableName.replaceAll("\"", "")
               val unQuotedDbSchema = tb.getDbSchema.replaceAll("\"", "")
               checkForComplexType(col, unQuotedName, unQuotedDbSchema, jdbcLayer)
-            case TableQuery(_,_) => Right(col)
+            case TableQuery(_,_,_) => Right(col)
           }
         )
           .toList

--- a/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
@@ -699,7 +699,7 @@ class SchemaTools(ctTools: ComplexTypesSchemaTools = new ComplexTypesSchemaTools
     // So finding a dot means we do not add a schema
     // Docs: https://www.vertica.com/docs/latest/HTML/Content/Authoring/SQLReferenceManual/Statements/SELECT/table-ref.htm
 
-    // This regex to capture sources that contain literals with schema defined, like: schema."table_name"
+    // This regex captures literal sources with a schema defined, ex: schema."table.name"
     val literalSourceWithSchema = "\\.\".*\"".r
     def noSchemaFound(source: String): Boolean = if (source.contains("\"")) {
       literalSourceWithSchema.findFirstIn(source).isEmpty

--- a/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
@@ -658,31 +658,31 @@ class SchemaTools(ctTools: ComplexTypesSchemaTools = new ComplexTypesSchemaTools
     }
   }
 
-  private def dotNotExistOutsideStringLiteral(str: String): Boolean = {
+  private def noDotOutsideStringLiteral(str: String): Boolean = {
 
     /**
      * Find the first dot outside of a string literal
      * */
     @tailrec
-    def dotExistsOutsideStringLiterals(str: String, quotationsCount: Int): Boolean = {
+    def dotOutsideStringLiterals(str: String, quotationsCount: Int): Boolean = {
       str.headOption match {
         case Some(head) => head match {
           // tracking if inside quotation
-          case '"' => dotExistsOutsideStringLiterals(str.tail, (quotationsCount + 1) % 2)
+          case '"' => dotOutsideStringLiterals(str.tail, (quotationsCount + 1) % 2)
           case '.' =>
             if (quotationsCount == 0) {
               // Only count dot if outside of string literal
               true
             } else {
-              dotExistsOutsideStringLiterals(str.tail, quotationsCount)
+              dotOutsideStringLiterals(str.tail, quotationsCount)
             }
-          case _ => dotExistsOutsideStringLiterals(str.tail, quotationsCount)
+          case _ => dotOutsideStringLiterals(str.tail, quotationsCount)
         }
         case None => false
       }
     }
 
-    !dotExistsOutsideStringLiterals(str, 0)
+    !dotOutsideStringLiterals(str, 0)
   }
 
   def addDbSchemaToQuery(query: String, dbSchema: Option[String]): String = {
@@ -698,7 +698,7 @@ class SchemaTools(ctTools: ComplexTypesSchemaTools = new ComplexTypesSchemaTools
         // Docs: https://www.vertica.com/docs/latest/HTML/Content/Authoring/SQLReferenceManual/Statements/SELECT/table-ref.htm
         val appendSchema: Boolean = if (source.contains("\"")) {
           // source can contains literal string like schema."df_test"
-          dotNotExistOutsideStringLiteral(source)
+          noDotOutsideStringLiteral(source)
         } else {
           source.split("\\.").length < 2
         }

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -1174,9 +1174,20 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
       == "SELECT * From schema.\"dftest\" join dftest2 on dftest.a = dftest2.b where x = 1")
   }
 
+  it should "add schema to query with literal table name \"df.test\" " in {
+    val query = "SELECT * From \"df.test\" join dftest2 on dftest.a = dftest2.b where x = 1"
+    assert(new SchemaTools().addDbSchemaToQuery(query, Some("schema"))
+      == "SELECT * From schema.\"df.test\" join dftest2 on dftest.a = dftest2.b where x = 1")
+  }
+
+  it should "not add schema to query with FROM source \"test.schema\".\"dftest\" " in {
+    val query2 = "SELECT * From \"test.schema\".\"df.test\" join dftest2 on dftest.a = dftest2.b where x = 1"
+    assert(new SchemaTools().addDbSchemaToQuery(query2, Some("schema")) == query2)
+  }
+
   it should "not add schema to query with literal table name, schema, and database" in {
-    val query = "SELECT * From \"data.base\".\"test\".\"df.test\" join dftest2 on dftest.a = dftest2.b where x = 1"
-    assert(new SchemaTools().addDbSchemaToQuery(query, Some("schema")) == query)
+    val query2 = "SELECT * From \"data.base\".\"test\".\"df.test\" join dftest2 on dftest.a = dftest2.b where x = 1"
+    assert(new SchemaTools().addDbSchemaToQuery(query2, Some("schema")) == query2)
   }
 
   it should "not add schema to query with some literal table name, schema, and database" in {

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -96,7 +96,7 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
   }
 
   it should "parse schema of query" in {
-    val query = TableQuery("SELECT * FROM t WHERE a > 1", "")
+    val query = TableQuery("SELECT * FROM t WHERE a > 1", "", None)
     val (jdbcLayer, _, rsmd) = mockJdbcDepsQuery(query)
 
     // Schema
@@ -114,7 +114,7 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
   }
 
   it should "fail when query's schema contains complex types" in {
-    val query = TableQuery("SELECT * FROM t WHERE a > 1", "")
+    val query = TableQuery("SELECT * FROM t WHERE a > 1", "", None)
     val (jdbcLayer, _, rsmd) = mockJdbcDepsQuery(query)
 
     // Schema

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -1174,12 +1174,12 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
       == "SELECT * From schema.\"dftest\" join dftest2 on dftest.a = dftest2.b where x = 1")
   }
 
-  it should "not add schema to query with escaped table name, schema, and database" in {
+  it should "not add schema to query with literal table name, schema, and database" in {
     val query = "SELECT * From \"database\".\"schema\".\"dftest\" join dftest2 on dftest.a = dftest2.b where x = 1"
     assert(new SchemaTools().addDbSchemaToQuery(query, Some("schema")) == query)
   }
 
-  it should "not add schema to query with some escaped table name, schema, and database" in {
+  it should "not add schema to query with some literal table name, schema, and database" in {
     val query = "SELECT * From database.\"schema\".dftest join dftest2 on dftest.a = dftest2.b where x = 1"
     assert(new SchemaTools().addDbSchemaToQuery(query, Some("schema")) == query)
   }

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -1148,9 +1148,9 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
   }
 
   it should "add schema to query" in {
-    val query = "SELECT * From dftest join dftest2 on dftest.a = dftest2.b where x = 1"
+    val query = "SELECT * From dftest join    dftest2 on dftest.a = dftest2.b where x = 1"
     assert(new SchemaTools().addDbSchemaToQuery(query, Some("schema"))
-      == "SELECT * From schema.dftest join dftest2 on dftest.a = dftest2.b where x = 1")
+      == "SELECT * From schema.dftest join    dftest2 on dftest.a = dftest2.b where x = 1")
   }
 
   it should "not add schema to query with sub-query in FROM clause" in {
@@ -1175,7 +1175,7 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
   }
 
   it should "not add schema to query with literal table name, schema, and database" in {
-    val query = "SELECT * From \"database\".\"schema\".\"df.test\" join dftest2 on dftest.a = dftest2.b where x = 1"
+    val query = "SELECT * From \"data.base\".\"test\".\"df.test\" join dftest2 on dftest.a = dftest2.b where x = 1"
     assert(new SchemaTools().addDbSchemaToQuery(query, Some("schema")) == query)
   }
 

--- a/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/schema/SchemaToolsTest.scala
@@ -1168,14 +1168,14 @@ class SchemaToolsTests extends AnyFlatSpec with MockFactory with org.scalatest.O
     assert(new SchemaTools().addDbSchemaToQuery(query, Some("schema")) == query)
   }
 
-  it should "add schema to query with escaped table name" in {
+  it should "add schema to query with literal table name" in {
     val query = "SELECT * From \"dftest\" join dftest2 on dftest.a = dftest2.b where x = 1"
     assert(new SchemaTools().addDbSchemaToQuery(query, Some("schema"))
       == "SELECT * From schema.\"dftest\" join dftest2 on dftest.a = dftest2.b where x = 1")
   }
 
   it should "not add schema to query with literal table name, schema, and database" in {
-    val query = "SELECT * From \"database\".\"schema\".\"dftest\" join dftest2 on dftest.a = dftest2.b where x = 1"
+    val query = "SELECT * From \"database\".\"schema\".\"df.test\" join dftest2 on dftest.a = dftest2.b where x = 1"
     assert(new SchemaTools().addDbSchemaToQuery(query, Some("schema")) == query)
   }
 

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/TestUtils.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/TestUtils.scala
@@ -153,4 +153,23 @@ object TestUtils {
     fsLayer.createDir(path, "777")
   }
 
+  def cascadeDropThenCreateSchema(schema: String, conn: Connection): Boolean = {
+    val stmt = conn.createStatement()
+    try{
+      stmt.execute(s"drop schema if exists $schema cascade")
+      stmt.execute(s"create schema $schema")
+    } finally {
+      stmt.close()
+    }
+  }
+
+  def cascadeDropSchema(schema: String, conn: Connection): Boolean = {
+    val stmt = conn.createStatement()
+    try{
+      stmt.execute(s"drop schema if exists $schema cascade")
+    } finally {
+      stmt.close()
+    }
+  }
+
 }

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/EndToEndTests.scala
@@ -4239,10 +4239,42 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     }
   }
 
+  it should "ignore dbschema option when reading a table using a query where string literals contains a dot" in {
+    val schema = "\"test.schema\""
+    val tableName = "\"df.test\""
+    val fullName = s"$schema.$tableName"
+    val stmt = conn.createStatement
+    val n = 1
+
+    TestUtils.cascadeDropThenCreateSchema(schema, conn)
+    TestUtils.createTableBySQL(conn, fullName, "create table " + fullName + " (a int)")
+
+    val insert = "insert into " + fullName + " values(2)"
+    TestUtils.populateTableBySQL(stmt, insert, n)
+
+    try {
+      val query = s"select * from $fullName"
+      val df: DataFrame = spark.read.format("com.vertica.spark.datasource.VerticaSource")
+        .options(
+          readOpts +
+            ("query" -> query) +
+            ("dbschema" -> "invalid-schema"))
+        .load()
+
+      assert(df.count() == 1)
+      df.rdd.foreach(row => assert(row.getAs[Long](0) == 2))
+
+    } catch {
+      case e: Exception => fail(e)
+    } finally {
+      TestUtils.cascadeDropSchema(schema, conn)
+    }
+  }
+
   it should "ignore dbschema option when reading a table using query containing schema, database, and string literals" in {
     val db = "docker"
-    val schema = "\"test_schema\""
-    val tableName = "\"df_test\""
+    val schema = "\"testschema\""
+    val tableName = "\"df.test\""
     val fullName = s"$db.$schema.$tableName"
     val stmt = conn.createStatement
     val n = 1


### PR DESCRIPTION
### Summary

Adding support for using `query` option with `dbschema` option.

### Description

With both defined, the schema specified in `dbschema` will be appended to the table name in the query's FROM clause. This will also work when string literals are used.
The `dbschema` _will not be appended_ if:

1. The FROM clause is a query.
2. The FROM clause already has a schema defined.

For reviewing, main code logic starts at `SchemaTools.addDbSchemaToQuery()`.

### Related Issue

Close #437 

### Additional Reviewers

@jeremyp-bq 
@jonathanl-bq 
@alexey-temnikov 
@alexr-bq 
