### PR TITLE
Update vertica version to 11.1.1 for post merge tests

### DIFF
--- a/.github/workflows/post-merge-testing.yml
+++ b/.github/workflows/post-merge-testing.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     env:
-      VERTICA_VERSION: 11.0.2-0
+      VERTICA_VERSION: 11.1.1-2
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     env:
-      VERTICA_VERSION: 11.0.2-0
+      VERTICA_VERSION: 11.1.1-2
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
@@ -142,7 +142,7 @@ jobs:
       - name: Run docker compose
         run: cd docker && docker-compose up -d
         env:
-          VERTICA_VERSION: 11.0.2-0
+          VERTICA_VERSION: 11.1.1-2
           GCS_HMAC_KEY_ID: ${{secrets.GCS_HMAC_KEY_ID}}
           GCS_HMAC_KEY_SECRET: ${{secrets.GCS_HMAC_KEY_SECRET}}
           GCS_SERVICE_KEY_ID: ${{secrets.GCS_SERVICE_KEY_ID}}


### PR DESCRIPTION
### Summary

Post merge tests were failing due to using Vertica 11.0 which does not have JSON support

### Additional Reviewers

@jeremyp-bq 
@jonathanl-bq 
@alexr-bq 
@alexey-temnikov 
