### PR TITLE
Fix failing Vertica 10 functional tests

### DIFF
--- a/functional-tests/src/main/scala/Main.scala
+++ b/functional-tests/src/main/scala/Main.scala
@@ -278,8 +278,7 @@ object Main extends App {
       new JDBCTests(jdbcConfig),
       new HDFSTests(fileStoreConfig, jdbcConfig),
       new CleanupUtilTests(fileStoreConfig),
-      new EndToEndTests(readOpts, writeOpts, jdbcConfig, fileStoreConfig),
-      new BasicJsonReadTests(readOpts, writeOpts, jdbcConfig, fileStoreConfig)
+      new EndToEndTests(readOpts, writeOpts, jdbcConfig, fileStoreConfig)
     )
 
     testSuites = if (options.v10) testSuites :+ new ComplexTypeTestsV10(readOpts, writeOpts, jdbcConfig, fileStoreConfig)


### PR DESCRIPTION
### Summary

The test was failing because it was including JSON tests which is not supported in Vertica 10.

### Additional Reviewers

@alexey-temnikov 
@jeremyp-bq 
@jonathanl-bq 
@alexr-bq 
