### PR TITLE
Automatic token authentication

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           project: Backlog
           column: Low Priority
-          repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   move-normal-priority:
     if: github.event.label.name == 'Normal Priority'
@@ -23,7 +23,7 @@ jobs:
         with:
           project: Backlog
           column: Normal Priority
-          repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   move-high-priority:
     if: github.event.label.name == 'High Priority'
@@ -33,5 +33,5 @@ jobs:
         with:
           project: Backlog
           column: High Priority
-          repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           

--- a/.github/workflows/remove-issue.yml
+++ b/.github/workflows/remove-issue.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           project: Backlog
           column: Low Priority
-          repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           action: delete
 
   remove-normal-priority:
@@ -24,7 +24,7 @@ jobs:
         with:
           project: Backlog
           column: Normal Priority
-          repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           action: delete
 
   remove-high-priority:
@@ -35,5 +35,5 @@ jobs:
         with:
           project: Backlog
           column: High Priority
-          repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           action: delete


### PR DESCRIPTION
### Summary

Automatic token authentication

### Description

Use the generic `secrets.GITHUB_TOKEN` instead of a personal token during actions.  It is enabled for read/write in the repo settings already.

See info [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).

### Related Issue

N/A

### Additional Reviewers

@Aryex 
@alexr-bq 
@jonathanl-bq 
@alexey-temnikov 
