### PR TITLE
Add GitHub token permissions

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -5,7 +5,8 @@ on:
       - labeled
   workflow_dispatch:
 permissions:
-  issues: write  
+  issues: write
+  repository-projects: write
 jobs:
   move-low-priority:
     if: github.event.label.name == 'Low Priority'

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -4,12 +4,14 @@ on:
     types:
       - labeled
   workflow_dispatch:
+permissions:
+  issues: write  
 jobs:
   move-low-priority:
     if: github.event.label.name == 'Low Priority'
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@5bcba1c1c091a222584d10913e5c060d32c44044
+      - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
           project: Backlog
           column: Low Priority
@@ -19,7 +21,7 @@ jobs:
     if: github.event.label.name == 'Normal Priority'
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@5bcba1c1c091a222584d10913e5c060d32c44044
+      - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
           project: Backlog
           column: Normal Priority
@@ -29,9 +31,8 @@ jobs:
     if: github.event.label.name == 'High Priority'
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@5bcba1c1c091a222584d10913e5c060d32c44044
+      - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
           project: Backlog
           column: High Priority
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          

--- a/.github/workflows/remove-issue.yml
+++ b/.github/workflows/remove-issue.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 permissions:
   issues: write
+  repository-projects: write
 jobs:
   remove-low-priority:
     if: contains(github.event.issue.labels.*.name, 'Low Priority')

--- a/.github/workflows/remove-issue.yml
+++ b/.github/workflows/remove-issue.yml
@@ -4,6 +4,8 @@ on:
     types:
       - closed
   workflow_dispatch:
+permissions:
+  issues: write
 jobs:
   remove-low-priority:
     if: contains(github.event.issue.labels.*.name, 'Low Priority')


### PR DESCRIPTION
### Summary

Add explicit write permissions (issues and repository-projects) for the issue-related actions.

### Description

Previously we changed the issue-related actions to use the GITHUB_TOKEN, but although the settings in the project allow for write access for the GITHUB_TOKEN, it is still failing.

If this does not fix the issue we will have to go back to using a personal access token instead of GITHUB_TOKEN.  An alternative would be to find another plugin to manage issues in our actions, other than github-project-automation-plus, which does work with the GITHUB_TOKEN.

### Related Issue

#487

### Additional Reviewers

@Aryex 
@alexr-bq 
@jonathanl-bq 
@alexey-temnikov 
