### PR TITLE
Set connection client label

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -177,6 +177,6 @@ jobs:
         with:
           repo_token: ${{secrets.GITHUB_TOKEN}}
           slack_webhook_url: ${{secrets.SLACK_CHANNEL_WEBHOOK}}
-          name: 'Nightly tests failed'
+          name: 'Weekly tests failed'
           icon_emoji: ':sadge:'
           include_jobs: false

--- a/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/jdbc/VerticaJdbcLayer.scala
@@ -156,6 +156,8 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
   private val thread = Thread.currentThread().getName + ": "
   private val prop = new util.Properties()
 
+  prop.put("LABEL", this.createClientLabel)
+
   cfg.auth match {
     case BasicJdbcAuth(username, password) =>
       Utils.ignore(prop.put("user", username))
@@ -187,7 +189,6 @@ class VerticaJdbcLayer(cfg: JDBCConfig) extends JdbcLayerInterface {
         lazyInitialized = true
         logger.debug(thread + "Connection lazy initialized")
         this.useConnection(conn, c => {
-          c.setClientInfo("APPLICATIONNAME", this.createClientLabel)
           c.setAutoCommit(false)
           logger.info(thread + "Successfully connected to Vertica.")
           c

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/JDBCTests.scala
@@ -206,7 +206,8 @@ class JDBCTests(val jdbcCfg: JDBCConfig, remote: Boolean) extends AnyFlatSpec wi
       case Right(rs) =>
         assert(rs.next())
         val label = rs.getString(1)
-        assert(label.contains("vspark-vs" + BuildInfo.version + "-p-sp" + SparkSession.active.sparkContext.version))
+        // Ignore the Spark version as it may not be present on remote executors
+        assert(label.startsWith("vspark-vs" + BuildInfo.version + "-p-sp"))
       case Left(err) =>
         fail(err.getFullContext)
     }


### PR DESCRIPTION
### Summary

Set connection client label.

### Description

Previously we set the APPLICATIONNAME using setClientInfo, which only set the client label on the v_monitor.sessions table.  By setting the LABEL (as a connection property) the client label is set on the v_montor.sessions and dc_session_starts tables.  It is important to set the client label on the dc_session_starts table to ensure we can track Spark Connector usage using the Vertica Data Collector utility.

Verified that the client label is set as expected (e.g. vspark-vs3.3.2-p-sp3.3.0) on both v_montor.sessions and dc_session_starts tables.

### Related Issue

Closes #494

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
@jonathanl-bq 
@aleximpert
