### PR TITLE
Failing weekly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
-      - name: Shutdown container first
+      - name: Remove existing docker containers
         run: cd docker && docker-compose down
       - name: Run docker compose
         run: cd docker && docker-compose up -d

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
+      - name: Remove existing docker containers
+        run: cd docker && docker-compose down
       - name: Run docker compose
         run: cd docker && docker-compose up -d
         env:
@@ -70,6 +72,8 @@ jobs:
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
+      - name: Remove existing docker containers
+        run: cd docker && docker-compose down
       - name: Run docker compose
         run: cd docker && docker-compose up -d
         env:


### PR DESCRIPTION
### Summary

Failing weekly tests by trying to remove any existing docker containers to avoid the port in use error.

### Description

Try removing any existing docker containers during matrix tests to ensure the port is not still in use.

We don't know if this will fix the issue, as it is intermittent.  We have not seen the issue in the nightly tests since we added this step, so hoping it will also help with the weekly tests.  Only time will tell since we cannot reproduce locally (only an issue for matrix tests in GitHub). 

### Related Issue

Follow-on to #484.

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
@jonathanl-bq 
@aleximpert 
