### PR TITLE
Fix examples build artifact name

### DIFF
--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -39,7 +39,7 @@ libraryDependencies ++= Seq(
 )
 
 //Assembly jar name
-assembly / assemblyJarName := s"vertica-spark-scala-examples"
+assembly / assemblyJarName := s"vertica-spark-scala-examples.jar"
 
 assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard


### PR DESCRIPTION
### Summary

Fix examples build artifact name.

### Description

Bug in build, without this change the examples build cannot be run in Spark.

### Related Issue

None.

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
@jonathanl-bq 
@aleximpert 
