### PR TITLE
added option for truncation in overwrite

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/config/WriteConfig.scala
+++ b/connector/src/main/scala/com/vertica/spark/config/WriteConfig.scala
@@ -89,7 +89,8 @@ final case class DistributedFilesystemWriteConfig(jdbcConfig: JDBCConfig,
                                                   saveJobStatusTable: Boolean,
                                                   mergeKey: Option[ValidColumnList] = None,
                                                   timeOperations : Boolean = true,
-                                                  arrayLength: Long = 0
+                                                  arrayLength: Long = 0,
+                                                  truncate: Boolean
                                                  ) extends WriteConfig {
   private var overwrite: Boolean = false
 

--- a/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/DSConfigSetup.scala
@@ -462,6 +462,17 @@ object DSConfigSetupUtils {
     config.get("target_table_sql").validNec
   }
 
+  def getTruncate(config: Map[String, String]): ValidationResult[Boolean] = {
+    config.get("truncate") match {
+      case Some(str) =>
+        str match {
+          case "true" => true.validNec
+          case "false" => false.validNec
+        }
+      case None => false.validNec
+    }
+  }
+
   def getCopyColumnList(config: Map[String, String]): ValidationResult[Option[ValidColumnList]] = {
     config.get("copy_column_list") match {
       case None => None.validNec
@@ -728,7 +739,8 @@ class DSWriteConfigSetup(val schema: Option[StructType], val pipeFactory: Vertic
           DSConfigSetupUtils.getSaveJobStatusTable(config),
           DSConfigSetupUtils.getMergeKey(config),
           DSConfigSetupUtils.getTimeOperations(config),
-          DSConfigSetupUtils.getArrayLength(config)
+          DSConfigSetupUtils.getArrayLength(config),
+          DSConfigSetupUtils.getTruncate(config)
           ).mapN(DistributedFilesystemWriteConfig)
       case None =>
         MissingSchemaError().invalidNec

--- a/connector/src/main/scala/com/vertica/spark/util/table/TableUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/table/TableUtils.scala
@@ -77,6 +77,11 @@ trait TableUtilsInterface {
   def dropTable(tablename: TableName): ConnectorResult[Unit]
 
   /**
+   * Truncates a given table if it exists.
+   */
+  def truncateTable(tablename: TableName): ConnectorResult[Unit]
+
+  /**
    * Creates a temporary table.
    *
    * @param tablename Name of table
@@ -258,6 +263,11 @@ class TableUtils(schemaTools: SchemaToolsInterface, jdbcLayer: JdbcLayerInterfac
   def dropTable(tablename: TableName): ConnectorResult[Unit] = {
     jdbcLayer.execute("DROP TABLE IF EXISTS " + tablename.getFullTableName)
       .left.map(err => err.context("JDBC Error dropping table"))
+  }
+
+  def truncateTable(tablename: TableName): ConnectorResult[Unit] = {
+    jdbcLayer.execute("TRUNCATE TABLE " + tablename.getFullTableName)
+      .left.map(err => err.context("JDBC Error truncating table"))
   }
 
   override def createTempTable(tablename: TableName, schema: StructType, strlen: Long, arrayLength: Long): ConnectorResult[Unit] = {

--- a/connector/src/test/scala/com/vertica/spark/common/TestObjects.scala
+++ b/connector/src/test/scala/com/vertica/spark/common/TestObjects.scala
@@ -35,7 +35,8 @@ object TestObjects {
     failedRowPercentTolerance = 0.0f,
     filePermissions = ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")),
     createExternalTable = None,
-    saveJobStatusTable = false
+    saveJobStatusTable = false,
+    truncate = false
   )
 
   val readConfig: DistributedFilesystemReadConfig = DistributedFilesystemReadConfig(

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/DSWriterTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/DSWriterTest.scala
@@ -43,7 +43,8 @@ class DSWriterTest extends AnyFlatSpec with BeforeAndAfterAll with MockFactory {
     failedRowPercentTolerance = 0.0f,
     filePermissions = ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")),
     createExternalTable = None,
-    saveJobStatusTable = false
+    saveJobStatusTable = false,
+    truncate = false
   )
 
   val uniqueId = "unique-id"

--- a/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/core/VerticaDistributedFilesystemWritePipeTest.scala
@@ -52,7 +52,8 @@ class VerticaDistributedFilesystemWritePipeTest extends AnyFlatSpec with BeforeA
       0.0f,
       ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")),
       None,
-      saveJobStatusTable = false
+      saveJobStatusTable = false,
+      truncate = false
     )
   }
 

--- a/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/datasource/v2/VerticaV2SourceTest.scala
@@ -87,7 +87,8 @@ class VerticaV2SourceTests extends AnyFlatSpec with BeforeAndAfterAll with MockF
     failedRowPercentTolerance =  0.0f,
     filePermissions = ValidFilePermissions("777").getOrElse(throw new Exception("File perm error")),
     createExternalTable = None,
-    saveJobStatusTable = false
+    saveJobStatusTable = false,
+    truncate = false
   )
 
   val intSchema = new StructType(Array(StructField("col1", IntegerType)))

--- a/examples/scala/src/main/scala/example/examples/BasicReadWriteExamples.scala
+++ b/examples/scala/src/main/scala/example/examples/BasicReadWriteExamples.scala
@@ -282,4 +282,5 @@ class BasicReadWriteExamples(spark: SparkSession) {
       spark.close()
     }
   }
+
 }

--- a/examples/scala/src/main/scala/example/examples/ConnectorOptionsExamples.scala
+++ b/examples/scala/src/main/scala/example/examples/ConnectorOptionsExamples.scala
@@ -169,4 +169,5 @@ class ConnectorOptionsExamples(spark: SparkSession) {
       spark.close()
     }
   }
+
 }

--- a/functional-tests/README.md
+++ b/functional-tests/README.md
@@ -81,19 +81,19 @@ Note that you should do this outside of the docker environment as it will be ext
 Navigate to the `functional-tests` folder on your local machine to build the functional test with `sbt assembly`. 
 Since the `spark-connector` folder is mounted onto the containers, the built jar will also be available on the client container.
 
-To submit the functional test to our standalone cluster, inside the client container navigate to `spark-connector/functional-tests` and use `submit-functional-test.sh`.
+To submit the functional test to our standalone cluster, inside the client container navigate to `spark-connector/functional-tests` and use `submit-functional-tests.sh`.
 
 Once submitted, verify through the [web ui](localhost:8080) and the [jobs ui](localhost:4040) that the application was submitted.
 Our functional test, without any arguments, will create multiple spark sessions; You should expect multiple applications executing one after another.
 
 #### Configuring the cluster.
-The `submit-functional-test.sh` uses `spark-submit` and thus you can edit any available spark config for the submission.
+The `submit-functional-tests.sh` uses `spark-submit` and thus you can edit any available spark config for the submission.
 
-`submit-functional-test.sh` will pass its arguments to `spark-submit`, thus passing the arguments to the submitted spark application.
-For example, to run a single test suite on our cluster, use `./submit-functional-test.sh -s EndToEndTests`.
+`submit-functional-tests.sh` will pass its arguments to `spark-submit`, thus passing the arguments to the submitted spark application.
+For example, to run a single test suite on our cluster, use `./submit-functional-tests.sh -s EndToEndTests`.
 
-Note: `submit-functional-test.sh` will always prepend the functional test option `-r` to the passed in arguments.
-So `./submit-functional-test.sh -s EndToEndTests` is equivalent to `sbt "run -r -s EndToEndTests"`
+Note: `submit-functional-tests.sh` will always prepend the functional test option `-r` to the passed in arguments.
+So `./submit-functional-tests.sh -s EndToEndTests` is equivalent to `sbt "run -r -s EndToEndTests"`
 Option `-r` tells our functional test application to configure itself for submitting to a cluster (by omitting the `master` option).
 
 To increase the worker count, change spark version, or any other Spark environment settings, refer to our [docker environment instructions](/docker/README.md).

--- a/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/EndToEndTests.scala
+++ b/functional-tests/src/main/scala/com/vertica/spark/functests/endtoend/EndToEndTests.scala
@@ -1103,6 +1103,44 @@ class EndToEndTests(readOpts: Map[String, String], writeOpts: Map[String, String
     TestUtils.dropTable(conn, tableName)
   }
 
+  it should "truncate table in overwrite mode" in {
+    val tableName = "truncTable"
+    val stmt = conn.createStatement()
+
+    TestUtils.createTableBySQL(conn, tableName, "create table " + tableName + " (col1 INTEGER)")
+    stmt.execute("INSERT INTO \"" + tableName + "\" VALUES(1)")
+    stmt.execute("CREATE USER ALEX")
+    stmt.execute("GRANT ALL PRIVILEGES ON TABLE " + tableName + " TO ALEX")
+
+    val schema = new StructType(Array(StructField("col1", IntegerType)))
+
+    val data = Seq(Row(77))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+    println(df.toString())
+    val mode = SaveMode.Overwrite
+
+    df.write.format("com.vertica.spark.datasource.VerticaSource").options(writeOpts + ("table" -> tableName, "truncate" -> "true")).mode(mode).save()
+
+
+    val query = "SELECT grantee, privileges_description FROM grants WHERE object_name='"+ tableName + "'"
+    stmt.execute("DROP USER ALEX")
+
+    try {
+      val rs = stmt.executeQuery(query)
+
+      assert (rs.getString(1) ==  "ALEX")
+    }
+    catch{
+      case err : Exception => fail(err)
+    }
+    finally {
+      stmt.close()
+    }
+
+    TestUtils.dropTable(conn, tableName)
+    
+  }
+
   it should "write data to Vertica and record job to status table" in {
     TestUtils.dropTable(conn, "S2V_JOB_STATUS_USER_" + readOpts.get("user").getOrElse("").toUpperCase())
 


### PR DESCRIPTION
### Summary

Some users require the option of truncating a table rather than dropping it in overwrite mode to retain table privileges. 

### Description

Truncate table was added to table utilities as well as the option of truncation through the dataframe writing options.

### Related Issue

#507 

### Additional Reviewers

@alexey-temnikov 
@jeremyp-bq 
@jonathanl-bq 
@alexr-bq 
