### PR TITLE
Update Vertica Docker image to work on M1

### DIFF
--- a/docker/docker-compose-kerberos.yml
+++ b/docker/docker-compose-kerberos.yml
@@ -64,6 +64,8 @@ services:
       - ./keytabs:/keytabs
     env_file:
       - krb.env
+    environment:
+      - VERTICA_MEMDEBUG=2
 
   hdfs:
     build: ./hdfs-krb

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - ./vertica-hdfs-config/hadoop:/etc/hadoop/conf
     environment:
       - VERTICA_VERSION
+      # Must set VERTICA_MEMDEBUG=2 in order for Vertica x86_64 image to run on Apple M1 machine
+      - VERTICA_MEMDEBUG=2
 
   hdfs:
     image: mdouchement/hdfs


### PR DESCRIPTION
### Summary

Update Vertica Docker image to work on M1.

### Description

Add `VERTICA_MEMDEBUG=2` environment variable so that the Vertica image works on Apple M1 machines.  If this is not set then the Vertica image fails to start on M1 machines.

Ran tests locally (on an Intel machine), as well as all GitHub action tests.  No issues with setting this as a default environment variable.

### Related Issue

Closes #515.

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
@ai-bq 
@jonathanl-bq 
