### PR TITLE
Tests updated to include Vertica 12.0.2

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,7 @@ Runs `main.yml` a pull requests to `main` (when a PR is created or has content p
 ### Nightly Tests
 The workflow `nightly.yml` runs nightly, from Monday to Friday at 9:18 AM GMT (or 2:18 AM Pacific Time), executing the 
 `main` branch against non-critical tests. It currently performs regression testing on combinations of Spark 3.x, with 
-the appropriate Hadoop HDFS, against Vertica 11.1.1-2 and 12.0.0-0. We also test against the latest Spark 3.x on a 
+the appropriate Hadoop HDFS, against Vertica 11.1.1-2 and 12.0.2-0. We also test against the latest Spark 3.x on a 
 standalone Spark cluster.
 
 ### Weekly Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     env:
-      VERTICA_VERSION: 12.0.0-0
+      VERTICA_VERSION: 12.0.2-0
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
-        vertica: ["11.1.1-2", "12.0.0-0" ]
+        vertica: ["11.1.1-2", "12.0.0-0", "12.0.2-0"]
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
-        vertica: ["11.1.1-2", "12.0.0-0", "12.0.2-0"]
+        vertica: ["11.1.1-2", "12.0.0-0", "12.0.2-0" ]
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
-        vertica: ["11.1.1-2", "12.0.0-0", "12.0.2-0" ]
+        vertica: ["11.1.1-2", "12.0.2-0" ]
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
         run: docker exec -w /spark-connector/functional-tests docker_client_1 sbt run
       - name: Remove docker containers
         run: cd docker && docker-compose down
-  run-intergration-tests-on-standalone-cluster:
+  run-integration-tests-on-standalone-cluster:
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build,
             run-spark-integration-tests,
-            run-intergration-tests-on-standalone-cluster]
+            run-integration-tests-on-standalone-cluster]
     if: failure()
     steps:
       - name: Slack Workflow Notification

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,7 +30,7 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
-        vertica: [ "12.0.0-0" ]
+        vertica: [ "12.0.2-0" ]
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,7 +30,6 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
-        vertica: [ "12.0.2-0" ]
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2


### PR DESCRIPTION
### Summary

Updating the tests to run on the latest version of Vertica. Nightly also has the previous version to test complex type parquet export before and after.

### Description

Version number 12.0.0 -> 12.0.2.

### Related Issue

Closes #513 and #514.

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
@jonathanl-bq 
@jeremyp-bq 
