### PR TITLE
Changed Vertica version comparisons to use relational operators

### DIFF
--- a/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
+++ b/connector/src/main/scala/com/vertica/spark/datasource/core/factory/VerticaPipeFactory.scala
@@ -76,7 +76,7 @@ object VerticaPipeFactory extends VerticaPipeFactoryInterface {
         }
 
         val verticaVersion = if(getVersion) VerticaVersionUtils.getVersionOrDefault(readLayerJdbc.get) else VERTICA_DEFAULT
-        val schemaTools = if (verticaVersion.lessThan(VERTICA_11)) new SchemaToolsV10 else new SchemaTools
+        val schemaTools = if (verticaVersion < VERTICA_11) new SchemaToolsV10 else new SchemaTools
 
         new VerticaDistributedFilesystemReadPipe(cfg, hadoopFileStoreLayer,
           readLayerJdbc.get,
@@ -97,8 +97,8 @@ object VerticaPipeFactory extends VerticaPipeFactoryInterface {
         val jdbcLayer = writeLayerJdbc.get
 //        This check is done so that executor won't create a jdbc connection through lazy init.
         val verticaVersion = if(getVersion) VerticaVersionUtils.getVersionOrDefault(jdbcLayer) else VERTICA_DEFAULT
-        val schemaTools = if (verticaVersion.lessThan(VERTICA_11)) new SchemaToolsV10 else new SchemaTools
-        if(verticaVersion.largerOrEqual(VERTICA_11_1_1)){
+        val schemaTools = if (verticaVersion < VERTICA_11) new SchemaToolsV10 else new SchemaTools
+        if(verticaVersion >= VERTICA_11_1_1){
           new VerticaDistributedFilesystemWritePipe(cfg,
             new HadoopFileStoreLayer(cfg.fileStoreConfig, Some(cfg.schema)),
             jdbcLayer,

--- a/connector/src/main/scala/com/vertica/spark/util/version/SparkVersionTools.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/version/SparkVersionTools.scala
@@ -53,7 +53,7 @@ class SparkVersionTools(reflection: ReflectionTools = new ReflectionTools) {
    * @return a compatible [[VerticaScanBuilder]] for the given spark version.
    * */
   def makeCompatibleVerticaScanBuilder(sparkVersion: Version, config: ReadConfig, readSetupInterface: DSConfigSetupInterface[ReadConfig]): VerticaScanBuilder = {
-    val sparkSupportsAggregatePushDown = sparkVersion.largerOrEqual(SPARK_3_2_0)
+    val sparkSupportsAggregatePushDown = sparkVersion >= SPARK_3_2_0
     if (sparkSupportsAggregatePushDown) {
       reflection.makeScanBuilderWithPushDown(config, readSetupInterface)
     } else {
@@ -68,7 +68,7 @@ class SparkVersionTools(reflection: ReflectionTools = new ReflectionTools) {
    * @return an array of [[Expression]] reprsenting the group-by columns.
    * */
   def getCompatibleGroupByExpressions(sparkVersion: Version, aggObj: Aggregation): Array[Expression] = {
-    if(sparkVersion.lessThan(SPARK_3_3_0)){
+    if(sparkVersion < SPARK_3_3_0){
       // $COVERAGE-OFF$
       reflection.aggregationInvokeMethod[Array[Expression]](aggObj, "groupByColumns")
       // $COVERAGE-ON$

--- a/connector/src/main/scala/com/vertica/spark/util/version/Version.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/version/Version.scala
@@ -19,16 +19,6 @@ package com.vertica.spark.util.version
  * */
 case class Version(major: Int, minor: Int = 0, servicePack: Int = 0, hotfix: Int = 0) extends Ordered[Version] {
 
-  def largerOrEqual(version: Version): Boolean = this.compare(version) >= 0
-
-  def largerThan(version: Version): Boolean = this.compare(version) > 0
-
-  def lesserOrEqual(version: Version): Boolean = this.compare(version) <= 0
-
-  def lessThan(version: Version): Boolean = this.compare(version) < 0
-
-  def isEquals(version: Version): Boolean =  this.compare(version) == 0
-
   override def toString: String = s"${major}.${minor}.${servicePack}-${hotfix}"
 
   override def compare(that: Version): Int =

--- a/connector/src/main/scala/com/vertica/spark/util/version/VerticaVersionUtils.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/version/VerticaVersionUtils.scala
@@ -88,7 +88,7 @@ object VerticaVersionUtils {
 
   def checkComplexTypesParquetExport(schema: StructType, version: Version): ConnectorResult[Unit] = {
     val (nativeCols, complexTypeCols) = complexTypeUtils.filterColumnTypes(schema)
-    if (version.lessThan(VERTICA_12_0_2)) {
+    if (version < VERTICA_12_0_2) {
       Left(ComplexTypeWriteNotSupported(complexTypeCols, version.toString))
     }
     else {
@@ -108,7 +108,7 @@ object VerticaVersionUtils {
       } else {
         Right()
       }
-    } else if (version.lesserOrEqual(VERTICA_11_1)) {
+    } else if (version <= VERTICA_11_1) {
       if (complexTypeCols.nonEmpty) {
         Left(ComplexTypeReadNotSupported(complexTypeCols, version.toString))
       } else {
@@ -123,7 +123,7 @@ object VerticaVersionUtils {
    * Export to Json was added in Vertica 11.1.1
    * */
   def checkJsonSupport(version: Version): ConnectorResult[Unit] =
-    if(version.lessThan(VERTICA_11_1_1)){
+    if(version < VERTICA_11_1_1){
       Left(ExportToJsonNotSupported(version.toString))
     } else {
       Right()

--- a/connector/src/test/scala/com/vertica/spark/util/version/SparkVersionToolsTests.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/version/SparkVersionToolsTests.scala
@@ -17,13 +17,13 @@ class SparkVersionToolsTests extends AnyFlatSpec with MockFactory{
   it should "correctly parses Spark version string" in {
     val version = (new SparkVersionTools).getVersion(Some("3.2.1"))
     assert(version.isDefined)
-    assert(version.get.isEquals(Version(3,2,1)))
+    assert(version == Some(Version(3,2,1)))
   }
 
   it should "correctly parses major-minor-patch numbers" in {
     val version = (new SparkVersionTools).getVersion(Some("3.2.1-0-vertica-1"))
     assert(version.isDefined)
-    assert(version.get.isEquals(Version(3,2,1)))
+    assert(version == Some(Version(3,2,1)))
   }
 
   it should "return a Spark version string" in {

--- a/connector/src/test/scala/com/vertica/spark/util/version/VersionTest.scala
+++ b/connector/src/test/scala/com/vertica/spark/util/version/VersionTest.scala
@@ -21,20 +21,20 @@ import org.scalatest.BeforeAndAfterAll
 class VersionTest extends AnyFlatSpec with BeforeAndAfterAll with MockFactory with org.scalatest.OneInstancePerTest {
 
   it should "compare to bigger version" in {
-    assert(Version(11, 1, 5, 3).largerThan(Version(10, 4, 7, 5)))
+    assert(Version(11, 1, 5, 3) > (Version(10, 4, 7, 5)))
   }
 
   it should "compare to smaller version" in {
-    assert(Version(11, 1, 5, 3).lessThan(Version(12, 0, 2, 1)))
+    assert(Version(11, 1, 5, 3) < (Version(12, 0, 2, 1)))
   }
 
   it should "compare to smaller or equal versions" in {
-    assert(Version(11, 1, 5, 3).lesserOrEqual(Version(11, 1, 5, 3)))
-    assert(Version(11, 1, 5, 3).lesserOrEqual(Version(11, 2, 5, 3)))
+    assert(Version(11, 1, 5, 3) <= (Version(11, 1, 5, 3)))
+    assert(Version(11, 1, 5, 3) <= (Version(11, 2, 5, 3)))
   }
 
   it should "compare to bigger or equal versions" in {
-    assert(Version(11, 1, 5, 3).largerOrEqual(Version(11, 1, 5, 3)))
-    assert(Version(11, 1, 5, 3).largerOrEqual(Version(11, 1, 5, 2)))
+    assert(Version(11, 1, 5, 3) >= (Version(11, 1, 5, 3)))
+    assert(Version(11, 1, 5, 3) >= (Version(11, 1, 5, 2)))
   }
 }


### PR DESCRIPTION
### Summary

The Spark Connector had Vertica versions compared through our own manually written functions. By extending the Ordered library we can use relational operators instead for cleaner code.

### Description

Every instance of the manual functions were replaced by relational operators. Afterwards, the previous functions were removed.

### Related Issue

Closes #518. 

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
