### PR TITLE
Java 8 isBlank fix + JDK 8 addition to Weekly workflow 

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,15 +9,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk: ['11', '8']
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.jdk }}
       - name: Build the project
         run: cd connector && sbt package
       - name: Upload the build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: build-jar-file
+          name: build-jar-file-${{ matrix.jdk }}
           path: /home/runner/work/spark-connector/spark-connector/connector/target/scala-2.12/spark-vertica-connector_2.12-*.jar
   run-spark-integration-tests-json:
     name: Run regression tests using JSON export
@@ -30,6 +37,7 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
+        jdk: ['11', '8']
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
@@ -44,7 +52,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file
+          name: build-jar-file-${{ matrix.jdk }}
           path: ./functional-tests/lib/
       - name: Wait for Vertica to be available
         uses: nick-invision/retry@v2
@@ -68,6 +76,7 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
+        jdk: ['11', '8']
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
@@ -82,7 +91,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file
+          name: build-jar-file-${{ matrix.jdk }}
           path: ./functional-tests/lib/
       - name: Wait for Vertica to be available
         uses: nick-invision/retry@v2
@@ -97,6 +106,9 @@ jobs:
         run: cd docker && docker-compose down
   run-integration-tests-s3:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk: ['11', '8']
     needs: build
     steps:
       - name: Checkout the project
@@ -104,7 +116,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file
+          name: build-jar-file-${{ matrix.jdk }}
           path: ./functional-tests/lib/
       - name: Add config options to application.conf
         run: cd functional-tests && ./pipeline-s3-config.sh
@@ -130,6 +142,9 @@ jobs:
         run: cd docker && docker-compose down
   run-integration-tests-gcs:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk: ['11', '8']
     needs: build
     steps:
       - name: Checkout the project
@@ -137,7 +152,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file
+          name: build-jar-file-${{ matrix.jdk }}
           path: ./functional-tests/lib/
       - name: Add config options to application.conf
         run: cd functional-tests && ./pipeline-gcs-config.sh

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file
+          name: build-jar-file-11
           path: ./functional-tests/lib/
       - name: Wait for Vertica to be available
         uses: nick-invision/retry@v2
@@ -128,7 +128,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file
+          name: build-jar-file-11
           path: ./functional-tests/lib/
       - name: Wait for Vertica to be available
         uses: nick-invision/retry@v2
@@ -150,7 +150,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file
+          name: build-jar-file-11
           path: ./functional-tests/lib/
       - name: Add config options to application.conf
         run: cd functional-tests && ./pipeline-s3-config.sh
@@ -183,7 +183,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file
+          name: build-jar-file-11
           path: ./functional-tests/lib/
       - name: Add config options to application.conf
         run: cd functional-tests && ./pipeline-gcs-config.sh
@@ -214,6 +214,7 @@ jobs:
     name: Post Workflow Status To Slack
     runs-on: ubuntu-latest
     needs: [build,
+            run-spark-integration-tests-jdk8,
             run-spark-integration-tests-json,
             run-spark-integration-tests-vertica-10,
             run-integration-tests-gcs,

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -109,6 +109,8 @@ jobs:
     strategy:
       matrix:
         jdk: ['11', '8']
+      fail-fast: true
+      max-parallel: 1
     needs: build
     steps:
       - name: Checkout the project
@@ -145,6 +147,8 @@ jobs:
     strategy:
       matrix:
         jdk: ['11', '8']
+      fail-fast: true
+      max-parallel: 1
     needs: build
     steps:
       - name: Checkout the project

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           name: build-jar-file-${{ matrix.jdk }}
           path: /home/runner/work/spark-connector/spark-connector/connector/target/scala-2.12/spark-vertica-connector_2.12-*.jar
-  run-spark-integration-tests-json:
-    name: Run regression tests using JSON export
+  run-spark-integration-tests-jdk8:
+    name: Run regression tests against different versions of Vertica
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -37,7 +37,7 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
-        jdk: ['11', '8']
+        vertica: ["11.1.1-2", "12.0.3-0" ]
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
@@ -52,7 +52,45 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file-${{ matrix.jdk }}
+          name: build-jar-file-8
+          path: ./functional-tests/lib/
+      - name: Wait for Vertica to be available
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 20
+          max_attempts: 10
+          retry_on: error
+          command: docker logs docker_vertica_1 | grep "Vertica container is now running" >/dev/null
+      - name: Run the integration tests
+        run: docker exec -w /spark-connector/functional-tests docker_client_1 sbt run
+      - name: Remove docker containers
+        run: cd docker && docker-compose down
+  run-spark-integration-tests-json:
+    name: Run regression tests using JSON export
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [ { spark: "[3.0.0, 3.1.0)", hadoop: "2.7.4" },
+                   { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
+                   { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
+                   { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v2
+      - name: Remove existing docker containers
+        run: cd docker && docker-compose down
+      - name: Run docker compose
+        run: cd docker && docker-compose up -d
+        env:
+          SPARK_VERSION: ${{matrix.runtime.spark}}
+          HADOOP_VERSION: ${{matrix.runtime.hadoop}}
+          VERTICA_VERSION: ${{matrix.vertica}}
+      - name: Download the build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-jar-file
           path: ./functional-tests/lib/
       - name: Wait for Vertica to be available
         uses: nick-invision/retry@v2
@@ -76,7 +114,6 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
-        jdk: ['11', '8']
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2
@@ -91,7 +128,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file-${{ matrix.jdk }}
+          name: build-jar-file
           path: ./functional-tests/lib/
       - name: Wait for Vertica to be available
         uses: nick-invision/retry@v2
@@ -106,11 +143,6 @@ jobs:
         run: cd docker && docker-compose down
   run-integration-tests-s3:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        jdk: ['11', '8']
-      fail-fast: true
-      max-parallel: 1
     needs: build
     steps:
       - name: Checkout the project
@@ -118,7 +150,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file-${{ matrix.jdk }}
+          name: build-jar-file
           path: ./functional-tests/lib/
       - name: Add config options to application.conf
         run: cd functional-tests && ./pipeline-s3-config.sh
@@ -144,11 +176,6 @@ jobs:
         run: cd docker && docker-compose down
   run-integration-tests-gcs:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        jdk: ['11', '8']
-      fail-fast: true
-      max-parallel: 1
     needs: build
     steps:
       - name: Checkout the project
@@ -156,7 +183,7 @@ jobs:
       - name: Download the build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build-jar-file-${{ matrix.jdk }}
+          name: build-jar-file
           path: ./functional-tests/lib/
       - name: Add config options to application.conf
         run: cd functional-tests && ./pipeline-gcs-config.sh

--- a/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
+++ b/connector/src/main/scala/com/vertica/spark/util/schema/SchemaTools.scala
@@ -22,6 +22,7 @@ import com.vertica.spark.util.error._
 import com.vertica.spark.util.error.ErrorHandling.{listToEitherSchema, ConnectorResult, SchemaResult}
 import com.vertica.spark.util.query.{ColumnInfo, ColumnsTable, ComplexTypesTable, StringParsingUtils}
 import com.vertica.spark.util.schema.ComplexTypesSchemaTools.{VERTICA_NATIVE_ARRAY_BASE_ID, VERTICA_SET_MAX_ID}
+import org.apache.commons.lang.StringUtils
 import org.apache.spark.sql.types._
 
 import java.sql.ResultSetMetaData
@@ -678,7 +679,7 @@ class SchemaTools(ctTools: ComplexTypesSchemaTools = new ComplexTypesSchemaTools
     def findEmptyColumnName(fields: List[StructField]): ConnectorResult[Unit] = {
       fields.headOption match {
         case Some(column) =>
-          if (column.name.isBlank) {
+          if (StringUtils.isBlank(column.name)) {
             Left(BlankColumnNamesError())
           } else {
             findEmptyColumnName(fields.tail)


### PR DESCRIPTION
### Summary

Java 8 was failing compilation of the Connector due to an unsupported method "isBlank." Additionally, Java 8 compilation is never tested and should be added to GH Actions.

### Description

Imported an Apache Commons StringUtil library to handle the isBlank method call. JDK 8 has yet to have been added to Weekly testing.

### Related Issue

Closes #534 and #536.

### Additional Reviewers

@alexey-temnikov 
@alexr-bq 
@jonathanl-bq 
@jeremyp-bq 
