### PR TITLE
Updated Vertica Docker entrypoint + workflows for 12.0.4

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,7 @@ Runs `main.yml` a pull requests to `main` (when a PR is created or has content p
 ### Nightly Tests
 The workflow `nightly.yml` runs nightly, from Monday to Friday at 9:18 AM GMT (or 2:18 AM Pacific Time), executing the 
 `main` branch against non-critical tests. It currently performs regression testing on combinations of Spark 3.x, with 
-the appropriate Hadoop HDFS, against Vertica 11.1.1-2 and 12.0.3-0. We also test against the latest Spark 3.x on a 
+the appropriate Hadoop HDFS, against Vertica 11.1.1-2 and 12.0.4-0. We also test against the latest Spark 3.x on a 
 standalone Spark cluster.
 
 ### Weekly Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
-        vertica: ["11.1.1-2", "12.0.3-0" ]
+        vertica: ["11.1.1-2", "12.0.4-0" ]
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -37,7 +37,7 @@ jobs:
                    { spark: "[3.1.0, 3.2.0)", hadoop: "3.2.0" },
                    { spark: "[3.2.0, 3.3.0)", hadoop: "3.3.1" },
                    { spark: "[3.3.0, 3.4.0)", hadoop: "3.3.2" } ]
-        vertica: ["11.1.1-2", "12.0.3-0" ]
+        vertica: ["11.1.1-2", "12.0.4-0" ]
     steps:
       - name: Checkout the project
         uses: actions/checkout@v2

--- a/docker/vertica/docker-entrypoint.sh
+++ b/docker/vertica/docker-entrypoint.sh
@@ -50,4 +50,5 @@ fi
 
 echo "Vertica container is now running"
 
+sudo ssh-keygen -q -A
 sudo /usr/sbin/sshd -D


### PR DESCRIPTION
### Summary

The Vertica kubernetes docker image was recently updated with changes regarding ssh keys shown [here.](https://github.com/vertica/vertica-kubernetes/pull/343/files#diff-48382ce1dc8be6b8b6f65290c65d12fdbb60bf23142d9dbbce09274c5a362740)

The Docker Log for our Vertica container would fail to execute its last line calling sshd as a result of there being no host keys.

The workflows should also be updated to 12.0.4.

### Description

Added a `sudo ssh-keygen -q -A` to generate new host keys.

Nightly test now [passes](https://github.com/vertica/spark-connector/actions/runs/4726162685).

Weekly and nightly workflows have been updated to Vertica 12.0.4, as has the README.

### Related Issue

Closes #540.
Closes #542.

### Additional Reviewers

@alexey-temnikov 
@jeremyp-bq 
@alexr-bq 
@jonathanl-bq 
