### PR TITLE
Pinned Spark version to 3.3.2

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -79,7 +79,7 @@ docker logs docker-hdfs-1
 
 To use a specific version set the following environment variables in your environment, such as in your Docker `.env` file:
 - `VERTICA_VERSION`: By default, we use the latest [Vertica](https://hub.docker.com/r/vertica/vertica-k8s) image. For example, to use Vertica 10.1.1-0 set `VERTICA_VERSION=10.1.1-0`.
-- `SPARK_INSTALL`: By default, we use the latest [Bitnami Spark](https://hub.docker.com/r/bitnami/spark) image. For example, to use Spark 3.1.3 set `SPARK_INSTALL=3.1.3`.
+- `SPARK_INSTALL`: By default, we use the 3.3.2 [Bitnami Spark](https://hub.docker.com/r/bitnami/spark) image. For example, to use Spark 3.1.3 set `SPARK_INSTALL=3.1.3`.
 
 By default we start a single Spark worker.  To start multiple Spark workers, such as 3 workers:
 ```sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./client
       args:
-        SPARK: ${SPARK_INSTALL:-latest}
+        SPARK: ${SPARK_INSTALL:-3.3.2}
     ports:
       # JVM Remote debug port
       - "5005:5005"
@@ -62,7 +62,7 @@ services:
     build:
       context: ./client
       args:
-        SPARK: ${SPARK_INSTALL:-latest}
+        SPARK: ${SPARK_INSTALL:-3.3.2}
     ports:
       - "8080:8080"
       - "7077:7077"
@@ -81,7 +81,7 @@ services:
     build:
       context: ./client
       args:
-        SPARK: ${SPARK_INSTALL:-latest}
+        SPARK: ${SPARK_INSTALL:-3.3.2}
     # Uncomment these ports to access the Spark Worker logs in the UI (not possible when scaling beyond a single worker node)
     #ports:
       #- "8081:8081"


### PR DESCRIPTION
### Summary

The spark version in the docker-compose file has been pinned to 3.3.2 to prevent test failures that were caused by using spark version 3.4 (from -latest tag).

### Description

Updated docker-compose and readme files.

### Related Issue

Addresses test failures described in #547 

### Additional Reviewers

@jeremyprime @AnatoliShein 
